### PR TITLE
Ensure Default Whisper Model is Present on Startup

### DIFF
--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -37,6 +37,7 @@ struct OpenSuperWhisperApp: App {
 
     init() {
         _ = ShortcutManager.shared
+        WhisperModelManager.shared.ensureDefaultModelPresent()
     }
 }
 

--- a/OpenSuperWhisper/WhisperModelManager.swift
+++ b/OpenSuperWhisper/WhisperModelManager.swift
@@ -72,8 +72,7 @@ class WhisperModelManager {
             return
         }
 
-        // Try to copy from app bundle (macOS), else from workspace root (Linux/dev)
-        #if os(macOS)
+        // Look for the model in the bundle
         if let bundleURL = Bundle.main.url(forResource: "ggml-tiny.en", withExtension: "bin") {
             do {
                 try FileManager.default.copyItem(at: bundleURL, to: destinationURL)

--- a/OpenSuperWhisper/WhisperModelManager.swift
+++ b/OpenSuperWhisper/WhisperModelManager.swift
@@ -66,10 +66,12 @@ class WhisperModelManager {
     private func copyDefaultModelIfNeeded() {
         let defaultModelName = "ggml-tiny.en.bin"
         let destinationURL = modelsDirectory.appendingPathComponent(defaultModelName)
+        
         // Check if model already exists
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             return
         }
+        
         // Look for the model in the bundle
         if let bundleURL = Bundle.main.url(forResource: "ggml-tiny.en", withExtension: "bin") {
             do {

--- a/OpenSuperWhisper/WhisperModelManager.swift
+++ b/OpenSuperWhisper/WhisperModelManager.swift
@@ -66,13 +66,11 @@ class WhisperModelManager {
     private func copyDefaultModelIfNeeded() {
         let defaultModelName = "ggml-tiny.en.bin"
         let destinationURL = modelsDirectory.appendingPathComponent(defaultModelName)
-
         // Check if model already exists
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             return
         }
-
-        // Look for the model in the bundle (macOS only)
+        // Look for the model in the bundle
         if let bundleURL = Bundle.main.url(forResource: "ggml-tiny.en", withExtension: "bin") {
             do {
                 try FileManager.default.copyItem(at: bundleURL, to: destinationURL)

--- a/OpenSuperWhisper/WhisperModelManager.swift
+++ b/OpenSuperWhisper/WhisperModelManager.swift
@@ -72,7 +72,7 @@ class WhisperModelManager {
             return
         }
 
-        // Look for the model in the bundle
+        // Look for the model in the bundle (macOS only)
         if let bundleURL = Bundle.main.url(forResource: "ggml-tiny.en", withExtension: "bin") {
             do {
                 try FileManager.default.copyItem(at: bundleURL, to: destinationURL)
@@ -81,19 +81,6 @@ class WhisperModelManager {
                 print("Failed to copy default model: \(error)")
             }
         }
-        #else
-        // Fallback: copy from workspace root if available
-        let rootPath = FileManager.default.currentDirectoryPath
-        let rootModelPath = (rootPath as NSString).appendingPathComponent(defaultModelName)
-        if FileManager.default.fileExists(atPath: rootModelPath) {
-            do {
-                try FileManager.default.copyItem(atPath: rootModelPath, toPath: destinationURL.path)
-                print("Copied default model from workspace root to: \(destinationURL.path)")
-            } catch {
-                print("Failed to copy default model from workspace root: \(error)")
-            }
-        }
-        #endif
     }
 
     // Call this on every startup to ensure at least one model is present

--- a/Readme.md
+++ b/Readme.md
@@ -47,3 +47,17 @@ Contributions are welcome! Please feel free to submit pull requests or create is
 ## License
 
 OpenSuperWhisper is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## Whisper Models
+
+You can download Whisper model files (`.bin`) from the [Whisper.cpp Hugging Face repository](https://huggingface.co/ggerganov/whisper.cpp/tree/main). Place the downloaded `.bin` files in the app's models directory. On first launch, the app will attempt to copy a default model automatically, but you can add more models manually.
+
+## How to Verify Model Auto-Repair
+
+To check that the auto-repair feature is working:
+
+1. Delete all `.bin` model files from the models directory. You can open this folder from the app's Settings ("Open Folder" button next to "Models Directory").
+2. Restart the app.
+3. The default model (`ggml-tiny.en.bin`) should be restored automatically, and the model selector will no longer be empty.
+
+If you want to add more models, simply download them from the link above and place them in the models directory.

--- a/Readme.md
+++ b/Readme.md
@@ -51,13 +51,3 @@ OpenSuperWhisper is licensed under the MIT License. See the [LICENSE](LICENSE) f
 ## Whisper Models
 
 You can download Whisper model files (`.bin`) from the [Whisper.cpp Hugging Face repository](https://huggingface.co/ggerganov/whisper.cpp/tree/main). Place the downloaded `.bin` files in the app's models directory. On first launch, the app will attempt to copy a default model automatically, but you can add more models manually.
-
-## How to Verify Model Auto-Repair
-
-To check that the auto-repair feature is working:
-
-1. Delete all `.bin` model files from the models directory. You can open this folder from the app's Settings ("Open Folder" button next to "Models Directory").
-2. Restart the app.
-3. The default model (`ggml-tiny.en.bin`) should be restored automatically, and the model selector will no longer be empty.
-
-If you want to add more models, simply download them from the link above and place them in the models directory.


### PR DESCRIPTION
issue from here: https://github.com/Starmel/OpenSuperWhisper/issues/22

After uninstalling and reinstalling, the model selector could be empty if the default model file is missing from the models directory.

Solution

On every app startup, the app now checks if the default model ([ggml-tiny.en.bin](https://github.com/Starmel/OpenSuperWhisper/compare/master...kiankyars:OpenSuperWhisper:master?expand=1)) exists in the models directory.

Added ensureDefaultModelPresent() to WhisperModelManager.
Called this method in OpenSuperWhisperApp's initializer.


also added information about other whisper.cpp models in hugging face readme.