### PR TITLE
Add on-device LLM post-processing for transcriptions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+        # Workaround: mlx-swift-lm LoRAContainer.swift uses 'consuming' keyword
+        # that triggers a Swift 6.1 ownership error (ml-explore/mlx-swift-lm#94).
+        # Pin to Xcode 16.2 (Swift 6.0) until upstream merges PR #95.
       - name: Install dependencies
         run: brew install cmake libomp rust
       - name: Set up Ruby (for xcpretty)
@@ -24,3 +29,5 @@ jobs:
         run: chmod +x ./run.sh
       - name: Build with run.sh
         run: ./run.sh build 
+        env:
+          OWS_INSTALL_METAL_TOOLCHAIN: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,4 @@ default.profraw
 *.dmg
 .cursorrules
 OpenSuperWhisper.dmg.sha256
-dev_config.json
+dev_config.jsonrun.log

--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		CE84DF722D55778000C54EA6 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF702D55778000C54EA6 /* MetalKit.framework */; };
 		CE84DF762D5577D200C54EA6 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF752D5577D200C54EA6 /* Accelerate.framework */; };
 		CE84E17D2D56550B00C54EA6 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = CE84E17C2D56550B00C54EA6 /* KeyboardShortcuts */; };
+		CE9DA56B2EA8DB0000EB417E /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = CE9DA5692EA8DB0000EB417E /* MLXLLM */; };
+		CE9DA56C2EA8DB0000EB417E /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = CE9DA56A2EA8DB0000EB417E /* MLXLMCommon */; };
 		CEAC00032D82F00200000000 /* libautocorrect_swift.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAC00012D82F00000000000 /* libautocorrect_swift.dylib */; };
 		CEAC00042D82F10000000000 /* libautocorrect_swift.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAC00012D82F00000000000 /* libautocorrect_swift.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		CEAC00082D82F50000000000 /* libomp.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAC00072D82F40000000000 /* libomp.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -219,6 +221,8 @@
 				CE84DF6E2D55777800C54EA6 /* libc++.tbd in Frameworks */,
 				840156D12D79EDA900FB5FFE /* libggml.a in Frameworks */,
 				CE84E17D2D56550B00C54EA6 /* KeyboardShortcuts in Frameworks */,
+				CE9DA56B2EA8DB0000EB417E /* MLXLLM in Frameworks */,
+				CE9DA56C2EA8DB0000EB417E /* MLXLMCommon in Frameworks */,
 				CEAC00032D82F00200000000 /* libautocorrect_swift.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -429,6 +433,8 @@
 				CE84E17C2D56550B00C54EA6 /* KeyboardShortcuts */,
 				CE0EAD6D2D56ACA80067FDEE /* GRDB */,
 				CE84E17E2D56550B00C54EA7 /* FluidAudio */,
+				CE9DA5692EA8DB0000EB417E /* MLXLLM */,
+				CE9DA56A2EA8DB0000EB417E /* MLXLMCommon */,
 			);
 			productName = OpenSuperWhisper;
 			productReference = CE57B0282D52C7BB00929AF3 /* OpenSuperWhisper.app */;
@@ -516,6 +522,7 @@
 				CE84E17B2D56550B00C54EA6 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 				CE0EAD6C2D56ACA80067FDEE /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				CE84E17D2D56550B00C54EA7 /* XCRemoteSwiftPackageReference "FluidAudio" */,
+				CE9DA5682EA8DB0000EB417E /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CE57B0292D52C7BB00929AF3 /* Products */;
@@ -820,6 +827,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/build",
 					/opt/homebrew/opt/libomp/lib,
+					/usr/local/opt/libomp/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.0.7;
@@ -882,6 +890,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/build",
 					/opt/homebrew/opt/libomp/lib,
+					/usr/local/opt/libomp/lib,
 				);
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
@@ -1050,6 +1059,14 @@
 				minimumVersion = 0.7.9;
 			};
 		};
+		CE9DA5682EA8DB0000EB417E /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm/";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.30.3;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1067,6 +1084,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CE84E17D2D56550B00C54EA7 /* XCRemoteSwiftPackageReference "FluidAudio" */;
 			productName = FluidAudio;
+		};
+		CE9DA5692EA8DB0000EB417E /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE9DA5682EA8DB0000EB417E /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLLM;
+		};
+		CE9DA56A2EA8DB0000EB417E /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE9DA5682EA8DB0000EB417E /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLMCommon;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b52b70f493c6c228eeb95f6561d91dd41131a6d3eba456cfebe020d41814380",
+  "originHash" : "9c47c6810570e1222de59c0472bf5750038c51786c23dc4d86fe9ca38a987827",
   "pins" : [
     {
       "identity" : "fluidaudio",
@@ -29,6 +29,24 @@
       }
     },
     {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
+        "version" : "0.30.6"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm/",
+      "state" : {
+        "revision" : "360c5052b81cc154b04ee0933597a4ad6db4b8ae",
+        "version" : "2.30.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -44,6 +62,15 @@
       "state" : {
         "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
         "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -112,7 +112,7 @@ class IndicatorViewModel: ObservableObject {
                 do {
                     print("start decoding...")
                     let text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
-                    
+
                     // Create a new Recording instance
                     let timestamp = Date()
                     let fileName = "\(Int(timestamp.timeIntervalSince1970)).wav"
@@ -122,15 +122,16 @@ class IndicatorViewModel: ObservableObject {
                         timestamp: timestamp,
                         fileName: fileName,
                         transcription: text,
+                        rawTranscription: text,
                         duration: 0,
                         status: .completed,
                         progress: 1.0,
                         sourceFileURL: nil
                     ).url
-                    
+
                     // Move the temporary recording to final location
                     try recorder.moveTemporaryRecording(from: tempURL, to: finalURL)
-                    
+
                     // Save the recording to store
                     await MainActor.run {
                         self.recordingStore.addRecording(Recording(
@@ -138,13 +139,14 @@ class IndicatorViewModel: ObservableObject {
                             timestamp: timestamp,
                             fileName: fileName,
                             transcription: text,
+                            rawTranscription: text,
                             duration: 0,
                             status: .completed,
                             progress: 1.0,
                             sourceFileURL: nil
                         ))
                     }
-                    
+
                     insertText(text)
                     print("Transcription result: \(text)")
                 } catch {
@@ -282,7 +284,7 @@ struct IndicatorWindow: View {
                     Image(systemName: "hourglass")
                         .foregroundColor(.orange)
                         .frame(width: 24)
-                    
+
                     Text("Processing...")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(.orange)

--- a/OpenSuperWhisper/LLM/DevModePrompts.swift
+++ b/OpenSuperWhisper/LLM/DevModePrompts.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct DevModePrompts {
+    static func buildPrompt() -> String {
+        return """
+            You are a technical writing assistant.
+            Convert spoken developer dictation into clean, structured markdown for an implementation request.
+
+            Rules:
+            - Remove verbal filler words and repetition.
+            - Preserve meaning and technical details exactly.
+            - Do NOT invent requirements, tools, or architecture.
+            - Do NOT write implementation code.
+            - Output markdown only (no preamble).
+
+            Preferred structure (omit empty sections):
+            ## Task
+            ## Context
+            ## Requirements
+            ## Constraints
+            ## Open Questions
+
+            For unclear points, keep wording cautious and place them under "Open Questions" instead of guessing.
+            """
+    }
+}

--- a/OpenSuperWhisper/LLM/LLMModelRegistry.swift
+++ b/OpenSuperWhisper/LLM/LLMModelRegistry.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+struct LLMModelInfo: Identifiable, Codable, Equatable {
+    let id: String
+    let displayName: String
+    let huggingFaceId: String
+    let sizeLabel: String
+    let description: String
+    let recommended: Bool
+
+    static func == (lhs: LLMModelInfo, rhs: LLMModelInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+struct LLMModelRegistry {
+    // MARK: - General Purpose Models
+
+    static let generalModels: [LLMModelInfo] = [
+        LLMModelInfo(
+            id: "qwen3-0.6b",
+            displayName: "Qwen3 0.6B",
+            huggingFaceId: "mlx-community/Qwen3-0.6B-4bit",
+            sizeLabel: "~335 MB",
+            description: "Fastest processing",
+            recommended: false
+        ),
+        LLMModelInfo(
+            id: "gemma3-1b",
+            displayName: "Gemma 3 1B",
+            huggingFaceId: "mlx-community/gemma-3-1b-it-4bit",
+            sizeLabel: "~733 MB",
+            description: "Fast processing, good accuracy",
+            recommended: false
+        ),
+        LLMModelInfo(
+            id: "llama3.2-3b",
+            displayName: "Llama 3.2 3B Instruct",
+            huggingFaceId: "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            sizeLabel: "~1.8 GB",
+            description: "Balanced speed and accuracy",
+            recommended: true
+        ),
+        LLMModelInfo(
+            id: "qwen3-4b",
+            displayName: "Qwen3 4B Instruct",
+            huggingFaceId: "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+            sizeLabel: "~2.3 GB",
+            description: "High accuracy, multilingual",
+            recommended: false
+        ),
+        LLMModelInfo(
+            id: "phi4-mini",
+            displayName: "Phi-4 Mini 3.8B",
+            huggingFaceId: "mlx-community/Phi-4-mini-instruct-4bit",
+            sizeLabel: "~2.2 GB",
+            description: "High accuracy, best reasoning",
+            recommended: false
+        ),
+    ]
+
+    // MARK: - Code-Specialized Models
+
+    static let codeModels: [LLMModelInfo] = [
+        LLMModelInfo(
+            id: "qwen2.5-coder-0.5b",
+            displayName: "Qwen2.5 Coder 0.5B",
+            huggingFaceId: "mlx-community/Qwen2.5-Coder-0.5B-Instruct-4bit",
+            sizeLabel: "~278 MB",
+            description: "Fastest processing, code-tuned",
+            recommended: false
+        ),
+        LLMModelInfo(
+            id: "qwen2.5-coder-1.5b",
+            displayName: "Qwen2.5 Coder 1.5B",
+            huggingFaceId: "mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit",
+            sizeLabel: "~869 MB",
+            description: "Fast processing, code-tuned",
+            recommended: false
+        ),
+        LLMModelInfo(
+            id: "qwen2.5-coder-3b",
+            displayName: "Qwen2.5 Coder 3B",
+            huggingFaceId: "mlx-community/Qwen2.5-Coder-3B-Instruct-4bit",
+            sizeLabel: "~1.7 GB",
+            description: "Balanced speed and accuracy, code-tuned",
+            recommended: false
+        ),
+    ]
+
+    static let availableModels: [LLMModelInfo] = generalModels + codeModels
+
+    static func model(forHuggingFaceId hfId: String) -> LLMModelInfo? {
+        availableModels.first { $0.huggingFaceId == hfId }
+    }
+
+    static var defaultModel: LLMModelInfo {
+        availableModels.first { $0.recommended } ?? availableModels[0]
+    }
+}

--- a/OpenSuperWhisper/LLM/LLMPostProcessor.swift
+++ b/OpenSuperWhisper/LLM/LLMPostProcessor.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+#if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+import MLX
+import MLXLLM
+import MLXLMCommon
+#endif
+
+enum LLMError: LocalizedError {
+    case unavailable
+    case modelNotLoaded
+    case emptyOutput
+    case processingFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "LLM runtime is unavailable in this build"
+        case .modelNotLoaded:
+            return "LLM model is not loaded"
+        case .emptyOutput:
+            return "LLM produced empty output"
+        case .processingFailed(let error):
+            return "LLM processing failed: \(error.localizedDescription)"
+        }
+    }
+}
+
+@MainActor
+class LLMPostProcessor: ObservableObject {
+    static let shared = LLMPostProcessor()
+
+    @Published var isModelLoaded = false
+    @Published var isLoadingModel = false
+    @Published var isProcessing = false
+    @Published var loadingProgress: Double = 0.0
+    @Published var lastError: String?
+    @Published private(set) var installedModelIds: Set<String> = []
+
+    var isBusy: Bool {
+        isLoadingModel || isProcessing
+    }
+
+    var isAvailable: Bool {
+        #if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+        true
+        #else
+        false
+        #endif
+    }
+
+    #if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+    private var modelContainer: ModelContainer?
+    private var currentModelId: String?
+    private var activeLoadTask: Task<ModelContainer, Error>?
+    private var activeLoadModelId: String?
+    private var activeLoadGeneration: UInt64 = 0
+    #endif
+
+    private init() {
+        installedModelIds = Set(AppPreferences.shared.installedLLMModelIds)
+        #if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+        MLX.Memory.cacheLimit = 20 * 1024 * 1024
+        #endif
+    }
+
+    func isModelInstalled(_ modelId: String) -> Bool {
+        installedModelIds.contains(modelId)
+    }
+
+    func loadModel(modelId: String) async throws {
+        #if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+        if currentModelId == modelId && isModelLoaded {
+            if !installedModelIds.contains(modelId) {
+                installedModelIds.insert(modelId)
+                AppPreferences.shared.installedLLMModelIds = Array(installedModelIds).sorted()
+            }
+            return
+        }
+
+        if activeLoadModelId == modelId, let activeLoadTask {
+            _ = try await activeLoadTask.value
+            return
+        }
+
+        if let activeLoadTask {
+            activeLoadTask.cancel()
+        }
+
+        modelContainer = nil
+        currentModelId = nil
+        isModelLoaded = false
+        isLoadingModel = true
+        isProcessing = false
+        loadingProgress = 0.0
+        lastError = nil
+        let configuration = ModelConfiguration(id: modelId)
+        activeLoadGeneration += 1
+        let generation = activeLoadGeneration
+
+        let task = Task.detached {
+            try await LLMModelFactory.shared.loadContainer(
+                configuration: configuration
+            ) { [weak self] progress in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    guard self.activeLoadGeneration == generation else { return }
+                    self.loadingProgress = progress.fractionCompleted
+                }
+            }
+        }
+
+        activeLoadTask = task
+        activeLoadModelId = modelId
+
+        defer {
+            if activeLoadGeneration == generation {
+                isLoadingModel = false
+                activeLoadTask = nil
+                activeLoadModelId = nil
+            }
+        }
+
+        do {
+            let container = try await task.value
+            guard activeLoadGeneration == generation else { return }
+
+            modelContainer = container
+            currentModelId = modelId
+            isModelLoaded = true
+            loadingProgress = 1.0
+            installedModelIds.insert(modelId)
+            AppPreferences.shared.installedLLMModelIds = Array(installedModelIds).sorted()
+        } catch {
+            guard activeLoadGeneration == generation else { return }
+
+            modelContainer = nil
+            currentModelId = nil
+            isModelLoaded = false
+            loadingProgress = 0.0
+            lastError = error.localizedDescription
+            throw error
+        }
+        #else
+        lastError = LLMError.unavailable.localizedDescription
+        throw LLMError.unavailable
+        #endif
+    }
+
+    func installModel(modelId: String) async throws {
+        try await loadModel(modelId: modelId)
+    }
+
+    func processText(_ text: String, mode: LLMProcessingMode) async throws -> String {
+        guard mode != .raw else { return text }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return text }
+
+        #if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+        let modelId = AppPreferences.shared.llmModelId
+
+        if !isModelLoaded || currentModelId != modelId {
+            try await loadModel(modelId: modelId)
+        }
+
+        guard let container = modelContainer else {
+            throw LLMError.modelNotLoaded
+        }
+
+        isProcessing = true
+        lastError = nil
+        defer { isProcessing = false }
+
+        let systemPrompt = mode.buildSystemPrompt(for: trimmed)
+        let temperature = AppPreferences.shared.llmTemperature
+
+        let result: String = try await container.perform { context in
+            let messages: [[String: String]] = [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": trimmed],
+            ]
+
+            let input = try await context.processor.prepare(
+                input: .init(messages: messages)
+            )
+
+            let maxTokens = 1024
+
+            let stream = try MLXLMCommon.generate(
+                input: input,
+                parameters: GenerateParameters(temperature: Float(temperature)),
+                context: context
+            )
+
+            var output = ""
+            var tokenCount = 0
+            for await generation in stream {
+                if case .chunk(let text) = generation {
+                    output += text
+                    tokenCount += 1
+                    if tokenCount >= maxTokens { break }
+                }
+            }
+
+            return output
+        }
+
+        let output = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        return output.isEmpty ? text : output
+        #else
+        lastError = LLMError.unavailable.localizedDescription
+        return text
+        #endif
+    }
+
+    func unloadModel() {
+        #if canImport(MLX) && canImport(MLXLLM) && canImport(MLXLMCommon)
+        activeLoadGeneration += 1
+        activeLoadTask?.cancel()
+        activeLoadTask = nil
+        activeLoadModelId = nil
+        modelContainer = nil
+        currentModelId = nil
+        #endif
+
+        isModelLoaded = false
+        isLoadingModel = false
+        isProcessing = false
+        loadingProgress = 0.0
+    }
+}

--- a/OpenSuperWhisper/LLM/LLMProcessingMode.swift
+++ b/OpenSuperWhisper/LLM/LLMProcessingMode.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum LLMProcessingMode: String, CaseIterable, Identifiable, Codable {
+    case raw, clean, dev, markdown
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .raw: return "Raw"
+        case .clean: return "Clean"
+        case .dev: return "Dev"
+        case .markdown: return "Markdown"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .raw: return "No processing (original transcription)"
+        case .clean: return "Remove filler words, fix grammar and punctuation"
+        case .dev: return "Restructure into a structured coding prompt"
+        case .markdown: return "Organize with headers, bullets, logical structure"
+        }
+    }
+
+    func buildSystemPrompt(for text: String) -> String {
+        switch self {
+        case .raw:
+            return ""
+        case .clean:
+            return Self.cleanPrompt
+        case .dev:
+            return DevModePrompts.buildPrompt()
+        case .markdown:
+            return Self.markdownPrompt
+        }
+    }
+
+    private static let cleanPrompt = """
+        You are a text editor. You receive raw speech transcription and output clean text.
+
+        Rules:
+        - Remove filler words: um, uh, like, basically, you know, I mean, so yeah, right
+        - Fix grammar and punctuation
+        - Merge broken sentences
+        - Do NOT add information. Do NOT summarize. Do NOT change meaning.
+        - Output ONLY the cleaned text, nothing else.
+
+        Example input: "so um basically I want to uh fix the bug where the login um form doesn't like validate the email"
+        Example output: "I want to fix the bug where the login form doesn't validate the email."
+        """
+
+    private static let markdownPrompt = """
+        You are a document formatter. You receive raw speech transcription and organize it into clean markdown.
+
+        Rules:
+        - Remove filler words (um, uh, like, basically, you know)
+        - Add markdown headers (##) for distinct topics
+        - Use bullet points for lists or multiple items
+        - Use bold for emphasis on key terms
+        - Keep all original meaning and detail
+        - Do NOT add information or commentary
+        - Output ONLY the formatted markdown
+
+        Example input: "so first we need to set up the database then we need to create the API endpoints and finally we need to build the frontend with React"
+        Example output:
+        ## Database Setup
+        - Set up the database
+
+        ## API Layer
+        - Create the API endpoints
+
+        ## Frontend
+        - Build the frontend with React
+        """
+}

--- a/OpenSuperWhisper/PermissionsManager.swift
+++ b/OpenSuperWhisper/PermissionsManager.swift
@@ -61,7 +61,8 @@ class PermissionsManager: ObservableObject {
     }
 
     func checkAccessibilityPermission() {
-        let granted = AXIsProcessTrusted()
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: false] as CFDictionary
+        let granted = AXIsProcessTrustedWithOptions(options)
         DispatchQueue.main.async { [weak self] in
             self?.isAccessibilityPermissionGranted = granted
         }

--- a/OpenSuperWhisper/TranscriptionQueue.swift
+++ b/OpenSuperWhisper/TranscriptionQueue.swift
@@ -262,6 +262,7 @@ class TranscriptionQueue: ObservableObject {
                     transcription: text,
                     progress: 1.0,
                     status: .completed,
+                    rawTranscription: text,
                     isRegeneration: false
                 )
 

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -107,4 +107,17 @@ final class AppPreferences {
     
     @UserDefault(key: "holdToRecord", defaultValue: true)
     var holdToRecord: Bool
+
+    // LLM post-processing settings
+    @UserDefault(key: "llmProcessingMode", defaultValue: "raw")
+    var llmProcessingMode: String
+
+    @UserDefault(key: "llmModelId", defaultValue: "mlx-community/Llama-3.2-3B-Instruct-4bit")
+    var llmModelId: String
+
+    @UserDefault(key: "llmTemperature", defaultValue: 0.3)
+    var llmTemperature: Double
+
+    @UserDefault(key: "installedLLMModelIds", defaultValue: [])
+    var installedLLMModelIds: [String]
 }

--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@ To build locally, you'll need:
     git submodule update --init --recursive
     brew install cmake libomp rust ruby
     gem install xcpretty
+    xcodebuild -downloadComponent MetalToolchain # one-time, needed for MLX packages
     ./run.sh build
 
 In case of problems, consult `.github/workflows/build.yml` which is our CI workflow


### PR DESCRIPTION
## Summary
- Adds manual per-recording LLM text processing using Apple MLX framework for on-device inference (no cloud API calls)
- Users can clean up filler words, restructure as developer prompts, or format as structured markdown via a wand menu on each recording
- New LLM module with model lifecycle management, curated model registry (0.5B–4B), and conditional compilation for non-MLX builds

## Details

### New files
- `OpenSuperWhisper/LLM/LLMPostProcessor.swift` — Singleton managing MLX model lifecycle with generation counter for async race protection, task coalescing for duplicate loads, and `Task.detached` for off-main-thread inference
- `OpenSuperWhisper/LLM/LLMProcessingMode.swift` — Processing mode enum (raw/clean/dev/markdown) with system prompts
- `OpenSuperWhisper/LLM/LLMModelRegistry.swift` — Curated registry of 8 MLX models (5 general purpose, 3 code-specialized)
- `OpenSuperWhisper/LLM/DevModePrompts.swift` — System prompt for converting spoken developer dictation to structured markdown

### Modified files
- **ContentView.swift** — Per-recording LLM processing via wand icon context menu, shimmer overlay during processing, revert-to-raw support
- **Settings.swift** — `@MainActor` on SettingsViewModel, Speech/LLM sub-tabs, model install flow with cancel button and rollback on failure/cancel (race-safe via model-id guards)
- **Recording.swift** — `rawTranscription` field, DB migration v3 with backfill
- **IndicatorWindow.swift** — `rawTranscription` set on hotkey recordings, removed dead `.processing` state
- **TranscriptionQueue.swift** — Passes `rawTranscription` through on transcription completion
- **AppPreferences.swift** — LLM preferences (processing mode, model ID, temperature, installed model IDs)
- **PermissionsManager.swift** — Use `AXIsProcessTrustedWithOptions` instead of `AXIsProcessTrusted()`
- **run.sh** — Dynamic libomp discovery, Metal Toolchain checks
- **project.pbxproj** — MLX framework references, mlx-swift-lm pinned to `upToNextMajorVersion: 2.30.3`

## Test plan
- [ ] Build with MLX enabled — verify LLM sub-tab appears, models can be installed/cancelled
- [ ] Build without MLX — verify app compiles, LLM UI shows "unavailable" messaging
- [ ] Record via main window — verify `rawTranscription` is set, wand menu works (clean/dev/markdown)
- [ ] Record via hotkey indicator — verify `rawTranscription` is set, revert-to-raw works
- [ ] Cancel model install mid-download — verify previous model is restored, no error toast
- [ ] Cancel then immediately install another model — verify no state clobbering (race scenario)
- [ ] Process text then revert to raw — verify original transcription is restored
- [ ] Drop audio file for transcription — verify rawTranscription is set on completion
- [ ] Run `./run.sh` on both Intel and Apple Silicon Macs

🤖 Generated with [Claude Code](https://claude.com/claude-code)