### PR TITLE
Add Finder audio file handling for all audio types

### DIFF
--- a/OpenSuperWhisper/OpenSuperWhisper-Info.plist
+++ b/OpenSuperWhisper/OpenSuperWhisper-Info.plist
@@ -4,6 +4,19 @@
 <dict>
 	<key>CFBundleIconFile</key>
 	<string>AppIcon.icns</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Audio Files</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.audio</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
I wanted to be able to right click on voicemails I download from my email and have them transcribed for being put in a call log. Possibly just have OSW be the default handler. I am not a swift programmer and I understand if you don't want AI code. I had codex make me some fixes and it was way over complicated so I had claude redo it into something much shorter of a fix.