### PR TITLE
Add Cmd+, shortcut to open settings

### DIFF
--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -647,6 +647,9 @@ struct ContentView: View {
         .sheet(isPresented: $isSettingsPresented) {
             SettingsView()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openSettings)) { _ in
+            isSettingsPresented = true
+        }
         .onChange(of: viewModel.shouldClearSearch) { _, shouldClear in
             if shouldClear {
                 searchText = ""

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -34,6 +34,15 @@ struct OpenSuperWhisperApp: App {
         .windowResizability(.contentMinSize)
         .commands {
             CommandGroup(replacing: .newItem) {}
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings...") {
+                    if let delegate = NSApplication.shared.delegate as? AppDelegate {
+                        delegate.showMainWindow()
+                    }
+                    NotificationCenter.default.post(name: .openSettings, object: nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
         }
         .handlesExternalEvents(matching: Set(arrayLiteral: "openMainWindow"))
     }

--- a/OpenSuperWhisper/Utils/NotificationName+App.swift
+++ b/OpenSuperWhisper/Utils/NotificationName+App.swift
@@ -4,4 +4,5 @@ extension Notification.Name {
     static let appPreferencesLanguageChanged = Notification.Name("AppPreferencesLanguageChanged")
     static let hotkeySettingsChanged = Notification.Name("HotkeySettingsChanged")
     static let indicatorWindowDidHide = Notification.Name("IndicatorWindowDidHide")
+    static let openSettings = Notification.Name("OpenSettings")
 }


### PR DESCRIPTION
## Summary
- Adds the standard macOS `Cmd+,` keyboard shortcut to open the Settings view
- Uses `CommandGroup(replacing: .appSettings)` in the app's Scene commands
- Notification-based approach triggers the settings sheet in ContentView, following existing codebase patterns

Closes #59

## Test plan
- [ ] Launch the app
- [ ] Press `Cmd+,` — Settings sheet should open
- [ ] If the main window is hidden (accessory mode), pressing `Cmd+,` should show the window first, then open settings
- [ ] Verify the "Settings..." menu item appears in the app menu (OpenSuperWhisper menu)