### PR TITLE
Add space after sentence feature and related tests

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -169,7 +169,17 @@ class IndicatorViewModel: ObservableObject {
     }
     
     func insertText(_ text: String) {
-        ClipboardUtil.insertText(text)
+        let finalText = Self.applyPostProcessing(text)
+        ClipboardUtil.insertText(finalText)
+    }
+    
+    static func applyPostProcessing(_ text: String) -> String {
+        guard AppPreferences.shared.addSpaceAfterSentence,
+              let lastChar = text.last,
+              lastChar.isPunctuation else {
+            return text
+        }
+        return text + " "
     }
     
     private func startBlinking() {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -136,6 +136,12 @@ class SettingsViewModel: ObservableObject {
         }
     }
     
+    @Published var addSpaceAfterSentence: Bool {
+        didSet {
+            AppPreferences.shared.addSpaceAfterSentence = addSpaceAfterSentence
+        }
+    }
+    
     init() {
         let prefs = AppPreferences.shared
         self.selectedEngine = prefs.selectedEngine
@@ -154,6 +160,7 @@ class SettingsViewModel: ObservableObject {
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
         self.holdToRecord = prefs.holdToRecord
+        self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
         
         if let savedPath = prefs.selectedWhisperModelPath ?? prefs.selectedModelPath {
             self.selectedModelURL = URL(fileURLWithPath: savedPath)
@@ -850,6 +857,20 @@ struct SettingsView: View {
                                 .font(.subheadline)
                             Spacer()
                             Toggle("", isOn: $viewModel.suppressBlankAudio)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+                        
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Add Space After Sentence")
+                                    .font(.subheadline)
+                                Text("Appends a space when transcription ends with punctuation")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $viewModel.addSpaceAfterSentence)
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
                                 .labelsHidden()
                         }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -107,4 +107,7 @@ final class AppPreferences {
     
     @UserDefault(key: "holdToRecord", defaultValue: true)
     var holdToRecord: Bool
+    
+    @UserDefault(key: "addSpaceAfterSentence", defaultValue: true)
+    var addSpaceAfterSentence: Bool
 }

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -959,3 +959,89 @@ final class KeyboardLayoutProviderTests: XCTestCase {
         print("=========================================\n")
     }
 }
+
+@MainActor
+final class AddSpaceAfterSentenceTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        AppPreferences.shared.addSpaceAfterSentence = true
+    }
+    
+    override func tearDown() {
+        AppPreferences.shared.addSpaceAfterSentence = true
+        super.tearDown()
+    }
+    
+    func testApplyPostProcessing_addsSpaceWhenEndsWithPeriod() {
+        let result = IndicatorViewModel.applyPostProcessing("Hello world.")
+        XCTAssertEqual(result, "Hello world. ")
+    }
+    
+    func testApplyPostProcessing_noSpaceWhenNoPeriod() {
+        let result = IndicatorViewModel.applyPostProcessing("Hello world")
+        XCTAssertEqual(result, "Hello world")
+    }
+    
+    func testApplyPostProcessing_noSpaceWhenDisabled() {
+        AppPreferences.shared.addSpaceAfterSentence = false
+        let result = IndicatorViewModel.applyPostProcessing("Hello world.")
+        XCTAssertEqual(result, "Hello world.")
+    }
+    
+    func testApplyPostProcessing_emptyString() {
+        let result = IndicatorViewModel.applyPostProcessing("")
+        XCTAssertEqual(result, "")
+    }
+    
+    func testApplyPostProcessing_onlyPeriod() {
+        let result = IndicatorViewModel.applyPostProcessing(".")
+        XCTAssertEqual(result, ". ")
+    }
+    
+    func testApplyPostProcessing_endsWithQuestionMark() {
+        let result = IndicatorViewModel.applyPostProcessing("How are you?")
+        XCTAssertEqual(result, "How are you? ")
+    }
+    
+    func testApplyPostProcessing_endsWithExclamationMark() {
+        let result = IndicatorViewModel.applyPostProcessing("Wow!")
+        XCTAssertEqual(result, "Wow! ")
+    }
+    
+    func testApplyPostProcessing_endsWithComma() {
+        let result = IndicatorViewModel.applyPostProcessing("First,")
+        XCTAssertEqual(result, "First, ")
+    }
+    
+    func testApplyPostProcessing_endsWithColon() {
+        let result = IndicatorViewModel.applyPostProcessing("Note:")
+        XCTAssertEqual(result, "Note: ")
+    }
+    
+    func testApplyPostProcessing_endsWithSemicolon() {
+        let result = IndicatorViewModel.applyPostProcessing("Done;")
+        XCTAssertEqual(result, "Done; ")
+    }
+    
+    func testApplyPostProcessing_endsWithEllipsis() {
+        let result = IndicatorViewModel.applyPostProcessing("Well...")
+        XCTAssertEqual(result, "Well... ")
+    }
+    
+    func testApplyPostProcessing_multipleSentences() {
+        let result = IndicatorViewModel.applyPostProcessing("First sentence. Second sentence.")
+        XCTAssertEqual(result, "First sentence. Second sentence. ")
+    }
+    
+    func testApplyPostProcessing_endsWithLetterNoSpace() {
+        let result = IndicatorViewModel.applyPostProcessing("No punctuation here")
+        XCTAssertEqual(result, "No punctuation here")
+    }
+    
+    func testApplyPostProcessing_defaultPreferenceIsEnabled() {
+        UserDefaults.standard.removeObject(forKey: "addSpaceAfterSentence")
+        let result = IndicatorViewModel.applyPostProcessing("Test.")
+        XCTAssertEqual(result, "Test. ")
+    }
+}


### PR DESCRIPTION
- Introduced a new user preference `addSpaceAfterSentence` in `AppPreferences` to control spacing after punctuation in transcriptions.
- Updated `IndicatorViewModel` to apply post-processing based on this preference when inserting text.
- Added UI toggle in `SettingsView` for users to enable or disable this feature.
- Implemented unit tests to verify the functionality of the new feature, ensuring correct behavior for various punctuation scenarios.