### PR TITLE
Show loading spinner while model initializes

### DIFF
--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -498,7 +498,7 @@ struct ContentView: View {
                                 viewModel.startRecording()
                             }
                         }) {
-                            if viewModel.state == .decoding || viewModel.state == .connecting {
+                            if viewModel.state == .decoding || viewModel.state == .connecting || viewModel.transcriptionService.isLoading {
                                 ProgressView()
                                     .scaleEffect(1.0)
                                     .frame(width: 48, height: 48)


### PR DESCRIPTION
## Summary
- The record button is silently disabled while the Whisper model loads (`isLoading=true`), but shows no visual feedback — it looks like a normal clickable button
- This causes confusion for users, especially with larger models like `large-v3-turbo` (1.5GB) which take ~30 seconds to load
- Fix: add `viewModel.transcriptionService.isLoading` to the spinner condition so the loading indicator is shown during model initialization

## Change
One-line change in `ContentView.swift`:

```swift
// Before:
if viewModel.state == .decoding || viewModel.state == .connecting {

// After:
if viewModel.state == .decoding || viewModel.state == .connecting || viewModel.transcriptionService.isLoading {
```

## Test plan
- [ ] Launch app with a large model (e.g., `large-v3-turbo`)
- [ ] Verify spinner appears on the record button while model loads
- [ ] Verify spinner disappears and button becomes clickable once model is ready
- [ ] Verify normal recording/transcription flow still works