### PR TITLE
fix: reliable paste into external apps after window/desktop switch

### DIFF
--- a/OpenSuperWhisper/Utils/ClipboardUtil.swift
+++ b/OpenSuperWhisper/Utils/ClipboardUtil.swift
@@ -81,8 +81,7 @@ class ClipboardUtil {
         let pollInterval: TimeInterval = 0.02 // 20 ms
 
         while Date() < deadline {
-            guard let source = CGEventSource(stateID: .hidSystemState) else { break }
-            let flags = source.flagsState
+            let flags = CGEventSource.flagsState(.hidSystemState)
             let modifiers: CGEventFlags = [.maskShift, .maskControl, .maskAlternate, .maskCommand]
             if flags.intersection(modifiers).isEmpty {
                 return


### PR DESCRIPTION
## Problem

The synthetic `Cmd+V` paste that inserts transcribed text into the active app is unreliable — it works initially but stops working after switching windows, desktops, or apps. The transcription itself completes correctly (visible in the app's history), but the text never reaches the target application.

This was reported in #80 and is a common pain point for users who use OpenSuperWhisper across multiple windows/desktops.

## Root causes

Three issues in `ClipboardUtil.swift`:

### 1. `CGEventSource(.combinedSessionState)` picks up stray modifiers

When the user's hotkey includes modifier keys (e.g. `Option+Space`), those keys may still be physically held when `sendCmdV()` fires. `.combinedSessionState` reflects the current session-level modifier state, so the target app receives e.g. `Option+Cmd+V` instead of `Cmd+V` and ignores it.

**Fix:** switched to `.hidSystemState` which reflects actual hardware state without session-level modifier contamination.

### 2. No waiting for modifier key release

Even with `.hidSystemState`, if the paste fires while the user is still releasing the hotkey, the event may carry stray flags.

**Fix:** added `waitForModifierRelease(timeout:)` that polls the hardware modifier state (20ms intervals, 1s timeout) before sending the synthetic paste.

### 3. Clipboard restore delay too short (100ms)

After posting `Cmd+V`, the original clipboard contents were restored after only 100ms. Apps that are mid-context-switch or on a different desktop may not have processed the paste event yet, causing them to read the restored (original) clipboard instead of the transcribed text.

**Fix:** increased the delay from 100ms to 300ms.

## Testing

Tested on macOS 15.4 (M4 Pro) with:
- Hotkey: `Option+Space` (toggle mode)
- Multiple desktops with different apps focused
- Rapid window switching between dictation attempts
- Italian and English transcription