### PR TITLE
Add toggle to skip inserting "No speech detected" message

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -145,8 +145,7 @@ class IndicatorViewModel: ObservableObject {
                         ))
                     }
 
-                    let isNoSpeech = text == "No speech detected in the audio"
-                    if !text.isEmpty && !(isNoSpeech && !AppPreferences.shared.insertNoSpeechMessage) {
+                    if !text.isEmpty && text != "No speech detected in the audio" {
                         insertText(text)
                     }
                     print("Transcription result: \(text)")

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -142,12 +142,6 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
-    @Published var insertNoSpeechMessage: Bool {
-        didSet {
-            AppPreferences.shared.insertNoSpeechMessage = insertNoSpeechMessage
-        }
-    }
-
     init() {
         let prefs = AppPreferences.shared
         self.selectedEngine = prefs.selectedEngine
@@ -167,7 +161,6 @@ class SettingsViewModel: ObservableObject {
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
         self.holdToRecord = prefs.holdToRecord
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
-        self.insertNoSpeechMessage = prefs.insertNoSpeechMessage
 
         if let savedPath = prefs.selectedWhisperModelPath ?? prefs.selectedModelPath {
             self.selectedModelURL = URL(fileURLWithPath: savedPath)
@@ -882,14 +875,6 @@ struct SettingsView: View {
                                 .labelsHidden()
                         }
 
-                        HStack {
-                            Text("Insert \"No Speech\" Message")
-                                .font(.subheadline)
-                            Spacer()
-                            Toggle("", isOn: $viewModel.insertNoSpeechMessage)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                        }
                     }
                 }
                 .padding()

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -110,7 +110,4 @@ final class AppPreferences {
     
     @UserDefault(key: "addSpaceAfterSentence", defaultValue: true)
     var addSpaceAfterSentence: Bool
-
-    @UserDefault(key: "insertNoSpeechMessage", defaultValue: true)
-    var insertNoSpeechMessage: Bool
 }


### PR DESCRIPTION
## Summary
- Adds an "Insert No Speech Message" toggle under Output Options in Transcription settings
- When disabled, prevents "No speech detected in the audio" from being pasted into the active window
- Useful when the mic picks up silence or background noise

## Test plan
- [ ] Enable the toggle (default) and verify "No speech detected" is pasted when no speech is recognized
- [ ] Disable the toggle and verify nothing is pasted when no speech is detected
- [ ] Verify normal transcriptions still work with the toggle in either state