### PR TITLE
Strip filler words from transcriptions via configurable regex

### DIFF
--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -188,7 +188,8 @@ class ContentViewModel: ObservableObject {
 
                 do {
                     print("start decoding...")
-                    let text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+                    let rawText = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+                    let text = AppPreferences.shared.cleanTranscription(rawText)
 
                     // Capture the current recording duration
                     let duration = await MainActor.run { self.recordingDuration }

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -111,8 +111,9 @@ class IndicatorViewModel: ObservableObject {
                 
                 do {
                     print("start decoding...")
-                    let text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
-                    
+                    let rawText = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+                    let text = AppPreferences.shared.cleanTranscription(rawText)
+
                     // Create a new Recording instance
                     let timestamp = Date()
                     let fileName = "\(Int(timestamp.timeIntervalSince1970)).wav"
@@ -127,10 +128,10 @@ class IndicatorViewModel: ObservableObject {
                         progress: 1.0,
                         sourceFileURL: nil
                     ).url
-                    
+
                     // Move the temporary recording to final location
                     try recorder.moveTemporaryRecording(from: tempURL, to: finalURL)
-                    
+
                     // Save the recording to store
                     await MainActor.run {
                         self.recordingStore.addRecording(Recording(

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -141,7 +141,19 @@ class SettingsViewModel: ObservableObject {
             AppPreferences.shared.addSpaceAfterSentence = addSpaceAfterSentence
         }
     }
-    
+
+    @Published var removeFillerWords: Bool {
+        didSet {
+            AppPreferences.shared.removeFillerWords = removeFillerWords
+        }
+    }
+
+    @Published var fillerWordsPattern: String {
+        didSet {
+            AppPreferences.shared.fillerWordsPattern = fillerWordsPattern
+        }
+    }
+
     init() {
         let prefs = AppPreferences.shared
         self.selectedEngine = prefs.selectedEngine
@@ -161,7 +173,9 @@ class SettingsViewModel: ObservableObject {
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
         self.holdToRecord = prefs.holdToRecord
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
-        
+        self.removeFillerWords = prefs.removeFillerWords
+        self.fillerWordsPattern = prefs.fillerWordsPattern
+
         if let savedPath = prefs.selectedWhisperModelPath ?? prefs.selectedModelPath {
             self.selectedModelURL = URL(fileURLWithPath: savedPath)
         }
@@ -907,7 +921,45 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color(.controlBackgroundColor).opacity(0.3))
                 .cornerRadius(12)
-                
+
+                // Filler Word Removal
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Filler Word Removal")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("Remove Filler Words")
+                                .font(.subheadline)
+                            Spacer()
+                            Toggle("", isOn: $viewModel.removeFillerWords)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+
+                        if viewModel.removeFillerWords {
+                            TextEditor(text: $viewModel.fillerWordsPattern)
+                                .frame(height: 60)
+                                .padding(6)
+                                .background(Color(.textBackgroundColor))
+                                .cornerRadius(8)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                                )
+
+                            Text("Regex pattern for filler words to remove from transcriptions. Uses case-insensitive matching.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
                 // Transcriptions Directory
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Transcriptions Directory")

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -110,4 +110,22 @@ final class AppPreferences {
     
     @UserDefault(key: "addSpaceAfterSentence", defaultValue: true)
     var addSpaceAfterSentence: Bool
+
+    @UserDefault(key: "removeFillerWords", defaultValue: false)
+    var removeFillerWords: Bool
+
+    @UserDefault(key: "fillerWordsPattern", defaultValue: "\\b(um|uh|uh huh|er|ah|hmm|mm)\\b,?\\s*")
+    var fillerWordsPattern: String
+
+    /// Applies filler word removal if enabled, then cleans up extra whitespace.
+    func cleanTranscription(_ text: String) -> String {
+        guard removeFillerWords, !fillerWordsPattern.isEmpty else { return text }
+        let cleaned = text.replacingOccurrences(
+            of: fillerWordsPattern,
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        // Collapse multiple spaces and trim
+        return cleaned.replacingOccurrences(of: "\\s{2,}", with: " ", options: .regularExpression).trimmingCharacters(in: .whitespaces)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds post-processing step to remove filler sounds (um, uh, er, ah, hmm, mm) from transcription output
- Feature is off by default, toggled via "Remove Filler Words" in Transcription settings
- Regex pattern is user-editable so users can customize which words get filtered
- Applied in both the main window and the indicator window transcription paths

## Test plan
- [ ] Verify transcriptions work normally with the feature disabled (default)
- [ ] Enable the toggle and verify filler words are stripped from output
- [ ] Edit the regex pattern and verify custom patterns work
- [ ] Verify whitespace is cleaned up properly after filler removal