### PR TITLE
Add clipboard settings for transcription output

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -170,7 +170,22 @@ class IndicatorViewModel: ObservableObject {
     
     func insertText(_ text: String) {
         let finalText = Self.applyPostProcessing(text)
-        ClipboardUtil.insertText(finalText)
+        let prefs = AppPreferences.shared
+
+        if prefs.autoPasteTranscription {
+            if prefs.autoCopyToClipboard {
+                // Paste and keep in clipboard
+                ClipboardUtil.insertTextAndKeepInClipboard(finalText)
+            } else {
+                // Paste but restore original clipboard (legacy behavior)
+                ClipboardUtil.insertText(finalText)
+            }
+        } else if prefs.autoCopyToClipboard {
+            // Only copy to clipboard, don't paste
+            ClipboardUtil.copyToClipboard(finalText)
+        }
+        // If both are false, do nothing
+
     }
     
     static func applyPostProcessing(_ text: String) -> String {

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -88,17 +88,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private var microphoneObserver: AnyCancellable?
     
     func applicationDidFinishLaunching(_ notification: Notification) {
-        
+
         setupStatusBarItem()
-        
+
         if let window = NSApplication.shared.windows.first {
             self.mainWindow = window
             window.delegate = self
-            
+
             window.minSize = NSSize(width: 450, height: 400)
             window.maxSize = NSSize(width: 450, height: 900)
         }
-        
+
         OpenSuperWhisperApp.startTranscriptionQueue()
         observeMicrophoneChanges()
     }

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -141,7 +141,19 @@ class SettingsViewModel: ObservableObject {
             AppPreferences.shared.addSpaceAfterSentence = addSpaceAfterSentence
         }
     }
-    
+
+    @Published var autoCopyToClipboard: Bool {
+        didSet {
+            AppPreferences.shared.autoCopyToClipboard = autoCopyToClipboard
+        }
+    }
+
+    @Published var autoPasteTranscription: Bool {
+        didSet {
+            AppPreferences.shared.autoPasteTranscription = autoPasteTranscription
+        }
+    }
+
     init() {
         let prefs = AppPreferences.shared
         self.selectedEngine = prefs.selectedEngine
@@ -161,7 +173,9 @@ class SettingsViewModel: ObservableObject {
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
         self.holdToRecord = prefs.holdToRecord
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
-        
+        self.autoCopyToClipboard = prefs.autoCopyToClipboard
+        self.autoPasteTranscription = prefs.autoPasteTranscription
+
         if let savedPath = prefs.selectedWhisperModelPath ?? prefs.selectedModelPath {
             self.selectedModelURL = URL(fileURLWithPath: savedPath)
         }
@@ -880,7 +894,48 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color(.controlBackgroundColor).opacity(0.3))
                 .cornerRadius(12)
-                
+
+                // Clipboard & Paste
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Clipboard & Paste")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Copy to Clipboard")
+                                    .font(.subheadline)
+                                Text("Keep transcription in clipboard after recording")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $viewModel.autoCopyToClipboard)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Auto-paste Transcription")
+                                    .font(.subheadline)
+                                Text("Automatically paste into the focused app")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $viewModel.autoPasteTranscription)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
                 // Initial Prompt
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Initial Prompt")

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -110,4 +110,11 @@ final class AppPreferences {
     
     @UserDefault(key: "addSpaceAfterSentence", defaultValue: true)
     var addSpaceAfterSentence: Bool
+
+    // Clipboard settings
+    @UserDefault(key: "autoCopyToClipboard", defaultValue: true)
+    var autoCopyToClipboard: Bool
+
+    @UserDefault(key: "autoPasteTranscription", defaultValue: true)
+    var autoPasteTranscription: Bool
 }

--- a/OpenSuperWhisper/Utils/ClipboardUtil.swift
+++ b/OpenSuperWhisper/Utils/ClipboardUtil.swift
@@ -3,23 +3,39 @@ import ApplicationServices
 import Carbon
 
 class ClipboardUtil {
-    
+
+    /// Copies text to clipboard without pasting or restoring
+    static func copyToClipboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString(text, forType: .string)
+    }
+
+    /// Pastes text and keeps it in clipboard (does not restore original clipboard)
+    static func insertTextAndKeepInClipboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString(text, forType: .string)
+        simulatePaste()
+    }
+
+    /// Pastes text and restores original clipboard (legacy behavior)
     static func insertText(_ text: String) {
         let pasteboard = NSPasteboard.general
-        
+
         // Save current pasteboard contents
         let savedContents = saveCurrentPasteboardContents()
-        
+
         // Set new text to pasteboard
         pasteboard.declareTypes([.string], owner: nil)
         pasteboard.setString(text, forType: .string)
-        
+
         // Simulate Cmd+V using layout-aware keycode resolution
         simulatePaste()
-        
+
         // Add a small delay to ensure paste operation completes
         Thread.sleep(forTimeInterval: 0.1)
-        
+
         // Restore original contents
         if let contents = savedContents {
             restorePasteboardContents(contents)


### PR DESCRIPTION
Implements feature request from issue #80:
- Add "Copy to Clipboard" setting to keep transcription in clipboard
- Add "Auto-paste Transcription" setting to control auto-paste behavior

New settings section "Clipboard & Paste" in Settings UI allows users to:
- Enable/disable copying transcription to clipboard (default: on)
- Enable/disable auto-paste into focused app (default: on)

This enables workflows where users can:
1. Just copy to clipboard without auto-pasting
2. Auto-paste and keep text in clipboard for easy re-pasting


UX:

https://github.com/user-attachments/assets/735ddd2d-8838-47d8-af86-c74662a803dc

