### PR TITLE
iOS Cycle 1: Foundation — xcframework, WhisperCore, iOS target shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-xcframework:
     runs-on: macos-latest
+    outputs:
+      cache-key: ${{ steps.xcfw-key.outputs.key }}
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v6
@@ -17,7 +19,8 @@ jobs:
         run: |
           WHISPER_HASH=$(git submodule status libwhisper/whisper.cpp | awk '{print $1}' | tr -d '+-')
           SCRIPT_HASH=$(shasum -a 256 Scripts/build-xcframework.sh | awk '{print $1}')
-          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}" >> "$GITHUB_OUTPUT"
+          XCODE_HASH=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')
+          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}-${XCODE_HASH}" >> "$GITHUB_OUTPUT"
       - name: Cache xcframework
         id: cache-xcframework
         uses: actions/cache@v4
@@ -41,17 +44,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Compute xcframework cache key
-        id: xcfw-key
-        run: |
-          WHISPER_HASH=$(git submodule status libwhisper/whisper.cpp | awk '{print $1}' | tr -d '+-')
-          SCRIPT_HASH=$(shasum -a 256 Scripts/build-xcframework.sh | awk '{print $1}')
-          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}" >> "$GITHUB_OUTPUT"
       - name: Restore xcframework cache
         uses: actions/cache@v4
         with:
           path: libwhisper/whisper.cpp/build-apple/whisper.xcframework
-          key: ${{ steps.xcfw-key.outputs.key }}
+          key: ${{ needs.build-xcframework.outputs.cache-key }}
           fail-on-cache-miss: true
       - name: Install dependencies
         run: brew install cmake rust
@@ -94,20 +91,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Compute xcframework cache key
-        id: xcfw-key
-        run: |
-          WHISPER_HASH=$(git submodule status libwhisper/whisper.cpp | awk '{print $1}' | tr -d '+-')
-          SCRIPT_HASH=$(shasum -a 256 Scripts/build-xcframework.sh | awk '{print $1}')
-          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}" >> "$GITHUB_OUTPUT"
       - name: Restore xcframework cache
         uses: actions/cache@v4
         with:
           path: libwhisper/whisper.cpp/build-apple/whisper.xcframework
-          key: ${{ steps.xcfw-key.outputs.key }}
+          key: ${{ needs.build-xcframework.outputs.cache-key }}
           fail-on-cache-miss: true
-      - name: Install CMake
-        run: brew install cmake
       - name: Build iOS app (simulator)
         run: |
           xcodebuild -scheme OpenSuperWhisper-iOS \
@@ -118,3 +107,13 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build 2>&1 | tail -20
           echo "iOS build successful!"
+      - name: Test iOS app (simulator)
+        run: |
+          xcodebuild test -scheme OpenSuperWhisper-iOS \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -derivedDataPath build-ios \
+            -skipPackagePluginValidation -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | tail -30
+          echo "iOS tests passed!"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,22 +5,116 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-xcframework:
     runs-on: macos-latest
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Compute xcframework cache key
+        id: xcfw-key
+        run: |
+          WHISPER_HASH=$(git submodule status libwhisper/whisper.cpp | awk '{print $1}' | tr -d '+-')
+          SCRIPT_HASH=$(shasum -a 256 Scripts/build-xcframework.sh | awk '{print $1}')
+          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}" >> "$GITHUB_OUTPUT"
+      - name: Cache xcframework
+        id: cache-xcframework
+        uses: actions/cache@v4
+        with:
+          path: libwhisper/whisper.cpp/build-apple/whisper.xcframework
+          key: ${{ steps.xcfw-key.outputs.key }}
+      - name: Install CMake
+        if: steps.cache-xcframework.outputs.cache-hit != 'true'
+        run: brew install cmake
+      - name: Build xcframework
+        if: steps.cache-xcframework.outputs.cache-hit != 'true'
+        run: |
+          chmod +x ./Scripts/build-xcframework.sh
+          ./Scripts/build-xcframework.sh
+
+  build-macos:
+    runs-on: macos-latest
+    needs: build-xcframework
+    steps:
+      - name: Checkout repository (with submodules)
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Compute xcframework cache key
+        id: xcfw-key
+        run: |
+          WHISPER_HASH=$(git submodule status libwhisper/whisper.cpp | awk '{print $1}' | tr -d '+-')
+          SCRIPT_HASH=$(shasum -a 256 Scripts/build-xcframework.sh | awk '{print $1}')
+          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}" >> "$GITHUB_OUTPUT"
+      - name: Restore xcframework cache
+        uses: actions/cache@v4
+        with:
+          path: libwhisper/whisper.cpp/build-apple/whisper.xcframework
+          key: ${{ steps.xcfw-key.outputs.key }}
+          fail-on-cache-miss: true
       - name: Install dependencies
-        run: brew install cmake libomp rust
+        run: brew install cmake rust
       - name: Set up Ruby (for xcpretty)
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'
       - name: Install xcpretty
         run: gem install xcpretty
-      - name: Make run.sh executable
-        run: chmod +x ./run.sh
-      - name: Build with run.sh
-        run: ./run.sh build 
+      - name: Build autocorrect-swift
+        run: |
+          mkdir -p build
+          cargo build -p autocorrect-swift --release --target aarch64-apple-darwin --manifest-path=asian-autocorrect/Cargo.toml
+          cp ./asian-autocorrect/target/aarch64-apple-darwin/release/libautocorrect_swift.dylib ./build/libautocorrect_swift.dylib
+          install_name_tool -id "@rpath/libautocorrect_swift.dylib" ./build/libautocorrect_swift.dylib
+          codesign --force --sign - ./build/libautocorrect_swift.dylib
+      - name: Build macOS app
+        run: |
+          xcodebuild -scheme OpenSuperWhisper \
+            -configuration Debug \
+            -jobs 8 \
+            -derivedDataPath build \
+            -destination 'platform=macOS,arch=arm64' \
+            -skipPackagePluginValidation -skipMacroValidation \
+            -UseModernBuildSystem=YES \
+            -clonedSourcePackagesDirPath SourcePackages \
+            -skipUnavailableActions \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            OTHER_CODE_SIGN_FLAGS="--entitlements OpenSuperWhisper/OpenSuperWhisper.entitlements" \
+            build 2>&1 | xcpretty --simple --color
+          echo "macOS build successful!"
+
+  build-ios:
+    runs-on: macos-latest
+    needs: build-xcframework
+    steps:
+      - name: Checkout repository (with submodules)
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Compute xcframework cache key
+        id: xcfw-key
+        run: |
+          WHISPER_HASH=$(git submodule status libwhisper/whisper.cpp | awk '{print $1}' | tr -d '+-')
+          SCRIPT_HASH=$(shasum -a 256 Scripts/build-xcframework.sh | awk '{print $1}')
+          echo "key=xcframework-${WHISPER_HASH}-${SCRIPT_HASH}" >> "$GITHUB_OUTPUT"
+      - name: Restore xcframework cache
+        uses: actions/cache@v4
+        with:
+          path: libwhisper/whisper.cpp/build-apple/whisper.xcframework
+          key: ${{ steps.xcfw-key.outputs.key }}
+          fail-on-cache-miss: true
+      - name: Install CMake
+        run: brew install cmake
+      - name: Build iOS app (simulator)
+        run: |
+          xcodebuild -scheme OpenSuperWhisper-iOS \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build-ios \
+            -skipPackagePluginValidation -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            build 2>&1 | tail -20
+          echo "iOS build successful!"

--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,4 @@ default.profraw
 *.dmg
 .cursorrules
 OpenSuperWhisper.dmg.sha256
-dev_config.json
+dev_config.jsonbuild-wc/

--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,6 @@ default.profraw
 *.dmg
 .cursorrules
 OpenSuperWhisper.dmg.sha256
-dev_config.jsonbuild-wc/
+dev_config.json
+build-wc/
+build-ios/

--- a/Bridge.h
+++ b/Bridge.h
@@ -5,5 +5,4 @@
 //  Created by user on 07.02.2025.
 //
 
-#include "whisper.h"
 #include "asian-autocorrect/autocorrect-swift/autocorrect_swift.h"

--- a/OpenSuperWhisper-iOS/Info.plist
+++ b/OpenSuperWhisper-iOS/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>OpenSuperWhisper needs microphone access to record and transcribe your speech locally on device.</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/OpenSuperWhisper-iOS/OpenSuperWhisper-iOS.entitlements
+++ b/OpenSuperWhisper-iOS/OpenSuperWhisper-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ru.starmel.OpenSuperWhisper</string>
+	</array>
+</dict>
+</plist>

--- a/OpenSuperWhisper-iOS/iOSApp.swift
+++ b/OpenSuperWhisper-iOS/iOSApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import WhisperCore
+
+@main
+struct OpenSuperWhisperIOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("OpenSuperWhisper iOS")
+                .onAppear {
+                    // Verify WhisperCore is linked and accessible
+                    print("WhisperCore loaded. Engine types available.")
+                    print("RecordingStore: \(RecordingStore.shared)")
+                }
+        }
+    }
+}

--- a/OpenSuperWhisper-iOSTests/OpenSuperWhisper_iOSTests.swift
+++ b/OpenSuperWhisper-iOSTests/OpenSuperWhisper_iOSTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import WhisperCore
+
+final class OpenSuperWhisper_iOSTests: XCTestCase {
+
+    func testWhisperCoreImport() {
+        // Verify WhisperCore types are accessible from the iOS test target
+        XCTAssertNotNil(TranscriptionService.shared)
+        XCTAssertNotNil(RecordingStore.shared)
+        XCTAssertNotNil(WhisperModelManager.shared)
+    }
+
+    func testRecordingStateEnum() {
+        let state = RecordingState.idle
+        XCTAssertEqual(state, RecordingState.idle)
+        XCTAssertNotEqual(state, RecordingState.recording)
+    }
+
+    func testTranscriptionSettings() {
+        let settings = TranscriptionSettings()
+        XCTAssertFalse(settings.translateToEnglish)
+        XCTAssertTrue(settings.suppressBlankAudio)
+    }
+
+    func testLanguageUtil() {
+        XCTAssertFalse(LanguageUtil.availableLanguages.isEmpty)
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("en"))
+        XCTAssertEqual(LanguageUtil.languageNames["en"], "English")
+    }
+
+    func testTextUtil() {
+        XCTAssertEqual(TextUtil.wordCount("hello world"), 2)
+        XCTAssertEqual(TextUtil.wordCount(""), 0)
+    }
+}

--- a/OpenSuperWhisper-iOSTests/OpenSuperWhisper_iOSTests.swift
+++ b/OpenSuperWhisper-iOSTests/OpenSuperWhisper_iOSTests.swift
@@ -9,27 +9,218 @@ final class OpenSuperWhisper_iOSTests: XCTestCase {
         XCTAssertNotNil(RecordingStore.shared)
         XCTAssertNotNil(WhisperModelManager.shared)
     }
+}
 
-    func testRecordingStateEnum() {
-        let state = RecordingState.idle
-        XCTAssertEqual(state, RecordingState.idle)
-        XCTAssertNotEqual(state, RecordingState.recording)
+// MARK: - RecordingState Tests
+
+final class RecordingStateiOSTests: XCTestCase {
+    func testAllCasesAreDistinct() {
+        let allCases: [RecordingState] = [.idle, .connecting, .recording, .decoding, .busy]
+        for i in 0..<allCases.count {
+            for j in (i + 1)..<allCases.count {
+                XCTAssertNotEqual(allCases[i], allCases[j],
+                    "\(allCases[i]) should not equal \(allCases[j])")
+            }
+        }
     }
 
-    func testTranscriptionSettings() {
+    func testEquality() {
+        XCTAssertEqual(RecordingState.idle, RecordingState.idle)
+        XCTAssertEqual(RecordingState.recording, RecordingState.recording)
+        XCTAssertEqual(RecordingState.connecting, RecordingState.connecting)
+        XCTAssertEqual(RecordingState.decoding, RecordingState.decoding)
+        XCTAssertEqual(RecordingState.busy, RecordingState.busy)
+    }
+
+    func testInequality() {
+        XCTAssertNotEqual(RecordingState.idle, RecordingState.recording)
+        XCTAssertNotEqual(RecordingState.recording, RecordingState.decoding)
+        XCTAssertNotEqual(RecordingState.connecting, RecordingState.busy)
+    }
+}
+
+// MARK: - TranscriptionSettings Tests
+
+final class TranscriptionSettingsiOSTests: XCTestCase {
+    func testDefaultValues() {
         let settings = TranscriptionSettings()
         XCTAssertFalse(settings.translateToEnglish)
         XCTAssertTrue(settings.suppressBlankAudio)
+        XCTAssertFalse(settings.showTimestamps)
+        XCTAssertFalse(settings.useBeamSearch)
     }
 
-    func testLanguageUtil() {
+    func testIsAsianLanguage_japanese() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ja"
+        XCTAssertTrue(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_chinese() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "zh"
+        XCTAssertTrue(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_korean() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ko"
+        XCTAssertTrue(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_english() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "en"
+        XCTAssertFalse(settings.isAsianLanguage)
+    }
+
+    func testShouldApplyAsianAutocorrect_asianWithAutocorrectOn() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ja"
+        settings.useAsianAutocorrect = true
+        XCTAssertTrue(settings.shouldApplyAsianAutocorrect)
+    }
+
+    func testShouldApplyAsianAutocorrect_asianWithAutocorrectOff() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ja"
+        settings.useAsianAutocorrect = false
+        XCTAssertFalse(settings.shouldApplyAsianAutocorrect)
+    }
+
+    func testShouldApplyAsianAutocorrect_nonAsianLanguage() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "en"
+        settings.useAsianAutocorrect = true
+        XCTAssertFalse(settings.shouldApplyAsianAutocorrect)
+    }
+
+    func testAsianLanguagesSetContainsExpectedCodes() {
+        XCTAssertEqual(TranscriptionSettings.asianLanguages, Set(["zh", "ja", "ko"]))
+    }
+}
+
+// MARK: - NoOpTextPostProcessor Tests
+
+final class NoOpTextPostProcessoriOSTests: XCTestCase {
+    func testReturnsInputUnchanged() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertEqual(processor.process("hello world", language: "en"), "hello world")
+    }
+
+    func testReturnsEmptyStringUnchanged() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertEqual(processor.process("", language: "en"), "")
+    }
+
+    func testReturnsUnicodeUnchanged() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertEqual(processor.process("こんにちは世界", language: "ja"), "こんにちは世界")
+    }
+}
+
+// MARK: - LanguageUtil Tests
+
+final class LanguageUtiliOSTests: XCTestCase {
+    func testAvailableLanguagesNotEmpty() {
         XCTAssertFalse(LanguageUtil.availableLanguages.isEmpty)
-        XCTAssertTrue(LanguageUtil.availableLanguages.contains("en"))
-        XCTAssertEqual(LanguageUtil.languageNames["en"], "English")
     }
 
-    func testTextUtil() {
-        XCTAssertEqual(TextUtil.wordCount("hello world"), 2)
+    func testAvailableLanguagesContainsEnglish() {
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("en"))
+    }
+
+    func testAvailableLanguagesContainsAutoDetect() {
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("auto"))
+    }
+
+    func testAvailableLanguagesContainsAsianLanguages() {
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("zh"))
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("ja"))
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("ko"))
+    }
+
+    func testLanguageNamesHasEntryForEachLanguage() {
+        for lang in LanguageUtil.availableLanguages {
+            XCTAssertNotNil(LanguageUtil.languageNames[lang],
+                "Missing language name for code: \(lang)")
+        }
+    }
+
+    func testLanguageNameLookup() {
+        XCTAssertEqual(LanguageUtil.languageNames["en"], "English")
+        XCTAssertEqual(LanguageUtil.languageNames["auto"], "Auto-detect")
+        XCTAssertEqual(LanguageUtil.languageNames["ja"], "Japanese")
+    }
+
+    func testLanguageNameForUnknownCodeIsNil() {
+        XCTAssertNil(LanguageUtil.languageNames["xx"])
+    }
+
+    func testGetSystemLanguageReturnsValidCode() {
+        let systemLang = LanguageUtil.getSystemLanguage()
+        XCTAssertFalse(systemLang.isEmpty)
+        // Should be either a known language code or "en" as fallback
+        let knownCodes = Set(LanguageUtil.availableLanguages + ["eng"])
+        XCTAssertTrue(knownCodes.contains(systemLang),
+            "getSystemLanguage() returned unexpected code: \(systemLang)")
+    }
+}
+
+// MARK: - TextUtil Tests
+
+final class TextUtiliOSTests: XCTestCase {
+    // Word count tests
+    func testWordCount_emptyString() {
         XCTAssertEqual(TextUtil.wordCount(""), 0)
+    }
+
+    func testWordCount_singleWord() {
+        XCTAssertEqual(TextUtil.wordCount("hello"), 1)
+    }
+
+    func testWordCount_multipleWords() {
+        XCTAssertEqual(TextUtil.wordCount("hello world"), 2)
+    }
+
+    func testWordCount_leadingTrailingWhitespace() {
+        XCTAssertEqual(TextUtil.wordCount("  hello world  "), 2)
+    }
+
+    func testWordCount_multipleSpaces() {
+        XCTAssertEqual(TextUtil.wordCount("hello    world"), 2)
+    }
+
+    func testWordCount_newlines() {
+        XCTAssertEqual(TextUtil.wordCount("hello\nworld\nfoo"), 3)
+    }
+
+    func testWordCount_whitespaceOnly() {
+        XCTAssertEqual(TextUtil.wordCount("   "), 0)
+    }
+
+    // Duration formatting tests
+    func testFormatDuration_zero() {
+        XCTAssertEqual(TextUtil.formatDuration(0), "0s")
+    }
+
+    func testFormatDuration_seconds() {
+        XCTAssertEqual(TextUtil.formatDuration(30), "30s")
+    }
+
+    func testFormatDuration_minutesAndSeconds() {
+        XCTAssertEqual(TextUtil.formatDuration(65), "1m 5s")
+    }
+
+    func testFormatDuration_exactMinutes() {
+        XCTAssertEqual(TextUtil.formatDuration(120), "2m 0s")
+    }
+
+    func testFormatDuration_hoursMinutesSeconds() {
+        XCTAssertEqual(TextUtil.formatDuration(3661), "1h 1m 1s")
+    }
+
+    func testFormatDuration_exactHours() {
+        XCTAssertEqual(TextUtil.formatDuration(3600), "1h 0m 0s")
     }
 }

--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -1012,6 +1012,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper.ios;
 				PRODUCT_NAME = OpenSuperWhisper;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1449,6 +1451,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper.ios;
 				PRODUCT_NAME = OpenSuperWhisper;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -7,50 +7,75 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		36EBC0227428844AC8411325 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBC1B35882771B03CCEE49 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBC306D04008635328DAE1 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBC6D475C8352BF3EA9EAF /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBC8F7DA3F51E4D546612A /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBC907DA520E4D7D750096 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBCA42DBEDA791E9C785E5 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBCB7D2726BE5C80C0338A /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBCC92099BD2EC03912BC9 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBCD229289171650A4E267 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBCD57CC6B8E2D3FC51EF5 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		36EBCE4EA0197EA30ECFA1F7 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		840156D02D79ED9900FB5FFE /* libwhisper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156CF2D79ED9900FB5FFE /* libwhisper.a */; };
-		840156D12D79EDA900FB5FFE /* libggml.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156C52D79ED9900FB5FFE /* libggml.a */; };
-		840156D22D79EDB500FB5FFE /* libggml-base.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156C72D79ED9900FB5FFE /* libggml-base.a */; };
-		840156D32D79EDBA00FB5FFE /* libggml-blas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156C92D79ED9900FB5FFE /* libggml-blas.a */; };
-		840156D42D79EDBA00FB5FFE /* libggml-cpu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156CB2D79ED9900FB5FFE /* libggml-cpu.a */; };
-		840156D52D79EDBA00FB5FFE /* libggml-metal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156CD2D79ED9900FB5FFE /* libggml-metal.a */; };
+		0B30B7C3587592E08BC695C6 /* TranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E395B49AC9E8F8CE96E033 /* TranscriptionService.swift */; };
+		155E35F9F4FF3D4EA882D8B7 /* TextUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633229BD1D28FC70BCA8AFAF /* TextUtil.swift */; };
+		1F7BCEF334364CA5750C09C5 /* NotificationName+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365AE4C4A54DDC320C59CB26 /* NotificationName+App.swift */; };
+		212A742687EBECDE4AAE3848 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = B39D0E31B7742ACE6E44AA6B /* GRDB */; };
+		23D98BA308A3C81EFB96B482 /* RecordingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4277DC9C8820065FB0CA5C /* RecordingState.swift */; };
+		2D4BD27C2D8AF979586D3331 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD8322234219B61A30A56E86 /* Cocoa.framework */; };
+		36EBC0227428844AC8411325 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBC1B35882771B03CCEE49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBC306D04008635328DAE1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBC6D475C8352BF3EA9EAF /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBC8F7DA3F51E4D546612A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBC907DA520E4D7D750096 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBCA42DBEDA791E9C785E5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBCB7D2726BE5C80C0338A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBCC92099BD2EC03912BC9 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBCD229289171650A4E267 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBCD57CC6B8E2D3FC51EF5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36EBCE4EA0197EA30ECFA1F7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		375B10C7021A2903EE1C669B /* TranscriptionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97573A448A6AD372E990D13B /* TranscriptionEngine.swift */; };
+		39225B597050FA6F4FC4F4EE /* Whis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9008233ECD4C6843BABC2425 /* Whis.swift */; };
+		3B541FB2AB42185CB9EC4841 /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */; };
+		3C36A4EB4D7211C8355D7DEF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED6DD44F3E416801E87F03E0 /* Foundation.framework */; };
+		3DA7D955AF233787F177D340 /* WhisperAhead.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B44F50E402A4C4C77712431 /* WhisperAhead.swift */; };
+		4300B00C93D1591C3D2FDF33 /* WhisperContextParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7669FDDE9E5C380D5EA4B3B /* WhisperContextParams.swift */; };
+		45514FE6BEA916ACB73513F8 /* WhisperAheads.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6E460F56472BC4B63D3C26 /* WhisperAheads.swift */; };
+		4635E0E6E82DC50B9B23DF71 /* WhisperAlignmentHeadsPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E959DEDFBBE8FC1B0818AC0 /* WhisperAlignmentHeadsPreset.swift */; };
+		49E7741E447161F9C1DC374B /* Combine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A5B26C52CF3A537FFFA1693 /* Combine.framework */; };
+		4AB577BEF319BC70F4704448 /* AppPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759B66F8D57252ADAC33A148 /* AppPreferences.swift */; };
+		6713BD2CAFC3EAE6929CDAB6 /* AudioRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BBDDFD41DE1920797A0D38 /* AudioRecording.swift */; };
+		6F77E7BD34BDF0FFCFC48B2E /* Recording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E738DCD057696459BF452F /* Recording.swift */; };
+		70E09C6DD3D2059E3042E031 /* WhisperCore.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		786D7490994D76CADEC5D845 /* WhisperFullParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724CED538D6779C4D2EB0465 /* WhisperFullParams.swift */; };
+		808FB8D1CAD6B343AEFC1CA1 /* WhisperModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB257272A13511525877662F /* WhisperModelManager.swift */; };
+		8D9B07107EB29FD4DADB0060 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62764F9A788014838EE43C6D /* iOSApp.swift */; };
+		9422583E9A7FCD1B6F5DA582 /* WhisperEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88876A01106D33F2430307F8 /* WhisperEngine.swift */; };
+		978EC0BBAF5E34E363F3AAA0 /* TextPostProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174E1385E31A3BABB5941F47 /* TextPostProcessor.swift */; };
+		9B5DE5906BAF005A91B4CDBD /* WhisperGrammarElementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C475147F21DBFA5AEF1203 /* WhisperGrammarElementType.swift */; };
+		A444E1B160151034CECF8BCA /* WhisperTokenData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1570C3627A3C4768F747B88 /* WhisperTokenData.swift */; };
+		AB2DF7488DE759A8D4D47BF0 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25FF761EFBE2052C4B587C7F /* AVFoundation.framework */; };
+		B46AFB44F223C41F0671CCA4 /* WhisperCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B5600CC4FCCEF9C28DD1EC66 /* WhisperTimings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CA9D8D8107B43FC0F92D6 /* WhisperTimings.swift */; };
+		B9E6EBD63F416D4333097320 /* WhisperModelLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418C87076AD234BDAB42F7E6 /* WhisperModelLoader.swift */; };
+		BC27FE3FC0072942D22F3192 /* whisper.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C56502A5976B91E625E64121 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CBEB5746C34EB6FF5E3775 /* ClipboardService.swift */; };
+		C86084DE560C03D8DDBF9DD5 /* TranscriptionQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2F8DE3C859E14E129FBE88 /* TranscriptionQueue.swift */; };
+		C963C41A3A9F6892D07CD596 /* TranscriptionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD27FFF332FF97C9FDEE661 /* TranscriptionSettings.swift */; };
 		CE0EAD6E2D56ACA80067FDEE /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = CE0EAD6D2D56ACA80067FDEE /* GRDB */; };
-		CE84DF6E2D55777800C54EA6 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF6D2D55777800C54EA6 /* libc++.tbd */; };
-		CE84DF712D55778000C54EA6 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF6F2D55778000C54EA6 /* Metal.framework */; };
-		CE84DF722D55778000C54EA6 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF702D55778000C54EA6 /* MetalKit.framework */; };
-		CE84DF762D5577D200C54EA6 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF752D5577D200C54EA6 /* Accelerate.framework */; };
 		CE84E17D2D56550B00C54EA6 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = CE84E17C2D56550B00C54EA6 /* KeyboardShortcuts */; };
 		CEAC00032D82F00200000000 /* libautocorrect_swift.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAC00012D82F00000000000 /* libautocorrect_swift.dylib */; };
 		CEAC00042D82F10000000000 /* libautocorrect_swift.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAC00012D82F00000000000 /* libautocorrect_swift.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		CEAC00082D82F50000000000 /* libomp.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAC00072D82F40000000000 /* libomp.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		CEDB64FB04A2B280183DDE3C /* WhisperCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */; };
+		D149368D0F01B3B5A478BCDA /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */; };
+		D165F0DF1F5F412855970752 /* LanguageUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58ADECF3FE03910E5B85459 /* LanguageUtil.swift */; };
+		DBC3B9C93C9A16A037DED1C2 /* WhisperCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */; };
+		E7623C3AEC1B364C0CE56923 /* whisper.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EBEB062E8277264104729EB0 /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */; };
+		F22DDDB0FD8999615A174CFD /* WhisperGrammarElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FDBD85DA6785286D529520 /* WhisperGrammarElement.swift */; };
+		F448117F940452DCB5699D99 /* WhisperSamplingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEF6EE5AD7A000AD3D34CF6 /* WhisperSamplingStrategy.swift */; };
+		FF2DF23B5217294F3B298DCE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98DD07858F9A2E43E8004DE2 /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		CEAC00052D82F00400000000 /* Copy Files */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				CEAC00042D82F00300000000 /* libautocorrect_swift.dylib in Copy Files */,
-			);
-			name = "Copy Files";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXContainerItemProxy section */
+		7E6E7BECDDF95C71F4E82A41 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE57B0202D52C7BB00929AF3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB177DB8D9F479C88750D3E3;
+			remoteInfo = WhisperCore;
+		};
 		840156C42D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
@@ -107,6 +132,13 @@
 			remoteGlobalIDString = CE57B0272D52C7BB00929AF3;
 			remoteInfo = OpenSuperWhisper;
 		};
+		F01A9FF660A6FD86D6B16ECB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE57B0202D52C7BB00929AF3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB177DB8D9F479C88750D3E3;
+			remoteInfo = WhisperCore;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -117,15 +149,59 @@
 			dstSubfolderSpec = 10;
 			files = (
 				CEAC00042D82F10000000000 /* libautocorrect_swift.dylib in CopyFiles */,
-				CEAC00082D82F50000000000 /* libomp.dylib in CopyFiles */,
+				70E09C6DD3D2059E3042E031 /* WhisperCore.framework in CopyFiles */,
+				E7623C3AEC1B364C0CE56923 /* whisper.xcframework in CopyFiles */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D03C2A821C1905CEBFEE636C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B46AFB44F223C41F0671CCA4 /* WhisperCore.framework in Embed Frameworks */,
+				BC27FE3FC0072942D22F3192 /* whisper.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01E738DCD057696459BF452F /* Recording.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Recording.swift; sourceTree = "<group>"; };
+		032CA9D8D8107B43FC0F92D6 /* WhisperTimings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperTimings.swift; sourceTree = "<group>"; };
+		0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "libwhisper/whisper.cpp/build-apple/whisper.xcframework"; sourceTree = SOURCE_ROOT; };
+		174E1385E31A3BABB5941F47 /* TextPostProcessor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextPostProcessor.swift; sourceTree = "<group>"; };
+		20CBEB5746C34EB6FF5E3775 /* ClipboardService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
+		25FF761EFBE2052C4B587C7F /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		31C475147F21DBFA5AEF1203 /* WhisperGrammarElementType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperGrammarElementType.swift; sourceTree = "<group>"; };
+		365AE4C4A54DDC320C59CB26 /* NotificationName+App.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NotificationName+App.swift"; sourceTree = "<group>"; };
+		3AEF6EE5AD7A000AD3D34CF6 /* WhisperSamplingStrategy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperSamplingStrategy.swift; sourceTree = "<group>"; };
+		418C87076AD234BDAB42F7E6 /* WhisperModelLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperModelLoader.swift; sourceTree = "<group>"; };
+		45BBDDFD41DE1920797A0D38 /* AudioRecording.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioRecording.swift; sourceTree = "<group>"; };
+		4C2F8DE3C859E14E129FBE88 /* TranscriptionQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionQueue.swift; sourceTree = "<group>"; };
+		5E959DEDFBBE8FC1B0818AC0 /* WhisperAlignmentHeadsPreset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperAlignmentHeadsPreset.swift; sourceTree = "<group>"; };
+		62764F9A788014838EE43C6D /* iOSApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		633229BD1D28FC70BCA8AFAF /* TextUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextUtil.swift; sourceTree = "<group>"; };
+		6A5B26C52CF3A537FFFA1693 /* Combine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Combine.framework; path = System/Library/Frameworks/Combine.framework; sourceTree = SDKROOT; };
+		6B44F50E402A4C4C77712431 /* WhisperAhead.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperAhead.swift; sourceTree = "<group>"; };
+		724CED538D6779C4D2EB0465 /* WhisperFullParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperFullParams.swift; sourceTree = "<group>"; };
+		759B66F8D57252ADAC33A148 /* AppPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppPreferences.swift; sourceTree = "<group>"; };
 		840156402D79E87600FB5FFE /* libwhisper.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libwhisper.xcodeproj; path = libwhisper/build/libwhisper.xcodeproj; sourceTree = "<group>"; };
 		840156592D79EA1A00FB5FFE /* Bridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bridge.h; sourceTree = "<group>"; };
+		88876A01106D33F2430307F8 /* WhisperEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperEngine.swift; sourceTree = "<group>"; };
+		8D888DE3A08A808B2A34ACCA /* OpenSuperWhisper-iOS.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = "OpenSuperWhisper-iOS.entitlements"; sourceTree = "<group>"; };
+		9008233ECD4C6843BABC2425 /* Whis.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Whis.swift; sourceTree = "<group>"; };
+		97573A448A6AD372E990D13B /* TranscriptionEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionEngine.swift; sourceTree = "<group>"; };
+		98DD07858F9A2E43E8004DE2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		9FD27FFF332FF97C9FDEE661 /* TranscriptionSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionSettings.swift; sourceTree = "<group>"; };
+		A1570C3627A3C4768F747B88 /* WhisperTokenData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperTokenData.swift; sourceTree = "<group>"; };
+		AD8322234219B61A30A56E86 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WhisperCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B7E395B49AC9E8F8CE96E033 /* TranscriptionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
+		BF4277DC9C8820065FB0CA5C /* RecordingState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingState.swift; sourceTree = "<group>"; };
+		CC6E460F56472BC4B63D3C26 /* WhisperAheads.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperAheads.swift; sourceTree = "<group>"; };
 		CE57B0282D52C7BB00929AF3 /* OpenSuperWhisper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenSuperWhisper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE57B0392D52C7BC00929AF3 /* OpenSuperWhisperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenSuperWhisperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE57B0432D52C7BC00929AF3 /* OpenSuperWhisperUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenSuperWhisperUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -169,6 +245,13 @@
 		CE84DF792D5578BE00C54EA6 /* jfk.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = jfk.wav; sourceTree = "<group>"; };
 		CEAC00012D82F00000000000 /* libautocorrect_swift.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libautocorrect_swift.dylib; path = build/libautocorrect_swift.dylib; sourceTree = "<group>"; };
 		CEAC00072D82F40000000000 /* libomp.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libomp.dylib; path = build/libomp.dylib; sourceTree = "<group>"; };
+		E33093051B5092AB46FEBEDA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E7669FDDE9E5C380D5EA4B3B /* WhisperContextParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperContextParams.swift; sourceTree = "<group>"; };
+		ED6DD44F3E416801E87F03E0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		F58ADECF3FE03910E5B85459 /* LanguageUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LanguageUtil.swift; sourceTree = "<group>"; };
+		F5FDBD85DA6785286D529520 /* WhisperGrammarElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperGrammarElement.swift; sourceTree = "<group>"; };
+		FB257272A13511525877662F /* WhisperModelManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperModelManager.swift; sourceTree = "<group>"; };
+		FD661BC69E117292731461C5 /* OpenSuperWhisper-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenSuperWhisper-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -192,34 +275,43 @@
 		};
 		CE57B03C2D52C7BC00929AF3 /* OpenSuperWhisperTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = OpenSuperWhisperTests;
 			sourceTree = "<group>";
 		};
 		CE57B0462D52C7BC00929AF3 /* OpenSuperWhisperUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = OpenSuperWhisperUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8C63CB343341E9D279941C9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D4BD27C2D8AF979586D3331 /* Cocoa.framework in Frameworks */,
+				D149368D0F01B3B5A478BCDA /* whisper.xcframework in Frameworks */,
+				212A742687EBECDE4AAE3848 /* GRDB in Frameworks */,
+				AB2DF7488DE759A8D4D47BF0 /* AVFoundation.framework in Frameworks */,
+				FF2DF23B5217294F3B298DCE /* Foundation.framework in Frameworks */,
+				49E7741E447161F9C1DC374B /* Combine.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CE57B0252D52C7BB00929AF3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				840156D52D79EDBA00FB5FFE /* libggml-metal.a in Frameworks */,
-				840156D42D79EDBA00FB5FFE /* libggml-cpu.a in Frameworks */,
-				840156D32D79EDBA00FB5FFE /* libggml-blas.a in Frameworks */,
-				CE84DF762D5577D200C54EA6 /* Accelerate.framework in Frameworks */,
-				840156D22D79EDB500FB5FFE /* libggml-base.a in Frameworks */,
-				CE84DF712D55778000C54EA6 /* Metal.framework in Frameworks */,
 				CE0EAD6E2D56ACA80067FDEE /* GRDB in Frameworks */,
-				CE84DF722D55778000C54EA6 /* MetalKit.framework in Frameworks */,
-				840156D02D79ED9900FB5FFE /* libwhisper.a in Frameworks */,
-				CE84DF6E2D55777800C54EA6 /* libc++.tbd in Frameworks */,
-				840156D12D79EDA900FB5FFE /* libggml.a in Frameworks */,
 				CE84E17D2D56550B00C54EA6 /* KeyboardShortcuts in Frameworks */,
 				CEAC00032D82F00200000000 /* libautocorrect_swift.dylib in Frameworks */,
+				CEDB64FB04A2B280183DDE3C /* WhisperCore.framework in Frameworks */,
+				3B541FB2AB42185CB9EC4841 /* whisper.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,9 +329,85 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ECCA6333544C285AA49917C1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C36A4EB4D7211C8355D7DEF /* Foundation.framework in Frameworks */,
+				DBC3B9C93C9A16A037DED1C2 /* WhisperCore.framework in Frameworks */,
+				EBEB062E8277264104729EB0 /* whisper.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0BB801AA30FAD9A03F00B3AE /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				45BBDDFD41DE1920797A0D38 /* AudioRecording.swift */,
+				20CBEB5746C34EB6FF5E3775 /* ClipboardService.swift */,
+				174E1385E31A3BABB5941F47 /* TextPostProcessor.swift */,
+			);
+			name = Protocols;
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		0BFE98A3BD522781285CB0E4 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				759B66F8D57252ADAC33A148 /* AppPreferences.swift */,
+				F58ADECF3FE03910E5B85459 /* LanguageUtil.swift */,
+				365AE4C4A54DDC320C59CB26 /* NotificationName+App.swift */,
+				633229BD1D28FC70BCA8AFAF /* TextUtil.swift */,
+			);
+			name = Utils;
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		2AC726E5E983A76642EF3B44 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				01E738DCD057696459BF452F /* Recording.swift */,
+				BF4277DC9C8820065FB0CA5C /* RecordingState.swift */,
+				9FD27FFF332FF97C9FDEE661 /* TranscriptionSettings.swift */,
+			);
+			name = Models;
+			path = Models;
+			sourceTree = "<group>";
+		};
+		4EC257E8A95ED83E481870BE /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				ED6DD44F3E416801E87F03E0 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		5F967FBB424C7B4B2F433212 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				AD8322234219B61A30A56E86 /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
+		6230A80D984CFC89A507FF51 /* WhisperCore */ = {
+			isa = PBXGroup;
+			children = (
+				F61D7D2D543BAC64D043935D /* Engines */,
+				2AC726E5E983A76642EF3B44 /* Models */,
+				0BB801AA30FAD9A03F00B3AE /* Protocols */,
+				4C2F8DE3C859E14E129FBE88 /* TranscriptionQueue.swift */,
+				B7E395B49AC9E8F8CE96E033 /* TranscriptionService.swift */,
+				0BFE98A3BD522781285CB0E4 /* Utils */,
+				D4C3B817648A1C9D89EA6CA9 /* Whis */,
+				FB257272A13511525877662F /* WhisperModelManager.swift */,
+			);
+			name = WhisperCore;
+			path = WhisperCore;
+			sourceTree = "<group>";
+		};
 		840156412D79E87600FB5FFE /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -272,6 +440,11 @@
 				CE84DF432D5557F600C54EA6 /* libwhisper.1.7.4.dylib */,
 				CE84DF422D550BD500C54EA6 /* Release-iphoneos */,
 				CE84DF332D550BB400C54EA6 /* ggml.build */,
+				5F967FBB424C7B4B2F433212 /* OS X */,
+				25FF761EFBE2052C4B587C7F /* AVFoundation.framework */,
+				98DD07858F9A2E43E8004DE2 /* Foundation.framework */,
+				6A5B26C52CF3A537FFFA1693 /* Combine.framework */,
+				4EC257E8A95ED83E481870BE /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -289,6 +462,9 @@
 				CE84DF772D55789800C54EA6 /* ggml-tiny.en.bin */,
 				CE84DF792D5578BE00C54EA6 /* jfk.wav */,
 				CE9DA5672EA8DA4600EB417E /* Recovered References */,
+				6230A80D984CFC89A507FF51 /* WhisperCore */,
+				0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */,
+				E42651422955BD6D714FF96F /* OpenSuperWhisper-iOS */,
 			);
 			sourceTree = "<group>";
 		};
@@ -298,6 +474,8 @@
 				CE57B0282D52C7BB00929AF3 /* OpenSuperWhisper.app */,
 				CE57B0392D52C7BC00929AF3 /* OpenSuperWhisperTests.xctest */,
 				CE57B0432D52C7BC00929AF3 /* OpenSuperWhisperUITests.xctest */,
+				B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */,
+				FD661BC69E117292731461C5 /* OpenSuperWhisper-iOS.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -405,9 +583,79 @@
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
+		D4C3B817648A1C9D89EA6CA9 /* Whis */ = {
+			isa = PBXGroup;
+			children = (
+				9008233ECD4C6843BABC2425 /* Whis.swift */,
+				6B44F50E402A4C4C77712431 /* WhisperAhead.swift */,
+				CC6E460F56472BC4B63D3C26 /* WhisperAheads.swift */,
+				5E959DEDFBBE8FC1B0818AC0 /* WhisperAlignmentHeadsPreset.swift */,
+				E7669FDDE9E5C380D5EA4B3B /* WhisperContextParams.swift */,
+				724CED538D6779C4D2EB0465 /* WhisperFullParams.swift */,
+				F5FDBD85DA6785286D529520 /* WhisperGrammarElement.swift */,
+				31C475147F21DBFA5AEF1203 /* WhisperGrammarElementType.swift */,
+				418C87076AD234BDAB42F7E6 /* WhisperModelLoader.swift */,
+				3AEF6EE5AD7A000AD3D34CF6 /* WhisperSamplingStrategy.swift */,
+				032CA9D8D8107B43FC0F92D6 /* WhisperTimings.swift */,
+				A1570C3627A3C4768F747B88 /* WhisperTokenData.swift */,
+			);
+			name = Whis;
+			path = Whis;
+			sourceTree = "<group>";
+		};
+		E42651422955BD6D714FF96F /* OpenSuperWhisper-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				62764F9A788014838EE43C6D /* iOSApp.swift */,
+				E33093051B5092AB46FEBEDA /* Info.plist */,
+				8D888DE3A08A808B2A34ACCA /* OpenSuperWhisper-iOS.entitlements */,
+			);
+			name = "OpenSuperWhisper-iOS";
+			path = "OpenSuperWhisper-iOS";
+			sourceTree = "<group>";
+		};
+		F61D7D2D543BAC64D043935D /* Engines */ = {
+			isa = PBXGroup;
+			children = (
+				97573A448A6AD372E990D13B /* TranscriptionEngine.swift */,
+				88876A01106D33F2430307F8 /* WhisperEngine.swift */,
+			);
+			name = Engines;
+			path = Engines;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		05B0C32DE02FB7E23202057D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		8A27DE96B81CEB6C2F0CB5D6 /* OpenSuperWhisper-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CCA89AA694CE2BB308E0B858 /* Build configuration list for PBXNativeTarget "OpenSuperWhisper-iOS" */;
+			buildPhases = (
+				74DE31CC509DDCD0B61B46B2 /* Sources */,
+				ECCA6333544C285AA49917C1 /* Frameworks */,
+				EB1D8E1ADC778A83551DDADD /* Resources */,
+				D03C2A821C1905CEBFEE636C /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				804EAED58FA8C3CF58FB5B5D /* PBXTargetDependency */,
+			);
+			name = "OpenSuperWhisper-iOS";
+			productName = "OpenSuperWhisper-iOS";
+			productReference = FD661BC69E117292731461C5 /* OpenSuperWhisper-iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
 		CE57B0272D52C7BB00929AF3 /* OpenSuperWhisper */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE57B04D2D52C7BC00929AF3 /* Build configuration list for PBXNativeTarget "OpenSuperWhisper" */;
@@ -420,6 +668,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				CBEC21463E82C81349FC7F65 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				CE57B02A2D52C7BB00929AF3 /* OpenSuperWhisper */,
@@ -451,8 +700,6 @@
 				CE57B03C2D52C7BC00929AF3 /* OpenSuperWhisperTests */,
 			);
 			name = OpenSuperWhisperTests;
-			packageProductDependencies = (
-			);
 			productName = OpenSuperWhisperTests;
 			productReference = CE57B0392D52C7BC00929AF3 /* OpenSuperWhisperTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -474,11 +721,30 @@
 				CE57B0462D52C7BC00929AF3 /* OpenSuperWhisperUITests */,
 			);
 			name = OpenSuperWhisperUITests;
-			packageProductDependencies = (
-			);
 			productName = OpenSuperWhisperUITests;
 			productReference = CE57B0432D52C7BC00929AF3 /* OpenSuperWhisperUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		FB177DB8D9F479C88750D3E3 /* WhisperCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A959AE174D876C1CC0E3A4D6 /* Build configuration list for PBXNativeTarget "WhisperCore" */;
+			buildPhases = (
+				05B0C32DE02FB7E23202057D /* Headers */,
+				CA8026447247214294976B31 /* Sources */,
+				8C63CB343341E9D279941C9A /* Frameworks */,
+				F7B556D5A8F4FC0485697817 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WhisperCore;
+			packageProductDependencies = (
+				B39D0E31B7742ACE6E44AA6B /* GRDB */,
+			);
+			productName = WhisperCore;
+			productReference = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -531,6 +797,8 @@
 				CE57B0272D52C7BB00929AF3 /* OpenSuperWhisper */,
 				CE57B0382D52C7BC00929AF3 /* OpenSuperWhisperTests */,
 				CE57B0422D52C7BC00929AF3 /* OpenSuperWhisperUITests */,
+				FB177DB8D9F479C88750D3E3 /* WhisperCore */,
+				8A27DE96B81CEB6C2F0CB5D6 /* OpenSuperWhisper-iOS */,
 			);
 		};
 /* End PBXProject section */
@@ -602,25 +870,81 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EB1D8E1ADC778A83551DDADD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F7B556D5A8F4FC0485697817 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		74DE31CC509DDCD0B61B46B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D9B07107EB29FD4DADB0060 /* iOSApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA8026447247214294976B31 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				375B10C7021A2903EE1C669B /* TranscriptionEngine.swift in Sources */,
+				9422583E9A7FCD1B6F5DA582 /* WhisperEngine.swift in Sources */,
+				6F77E7BD34BDF0FFCFC48B2E /* Recording.swift in Sources */,
+				23D98BA308A3C81EFB96B482 /* RecordingState.swift in Sources */,
+				C963C41A3A9F6892D07CD596 /* TranscriptionSettings.swift in Sources */,
+				6713BD2CAFC3EAE6929CDAB6 /* AudioRecording.swift in Sources */,
+				C56502A5976B91E625E64121 /* ClipboardService.swift in Sources */,
+				978EC0BBAF5E34E363F3AAA0 /* TextPostProcessor.swift in Sources */,
+				C86084DE560C03D8DDBF9DD5 /* TranscriptionQueue.swift in Sources */,
+				0B30B7C3587592E08BC695C6 /* TranscriptionService.swift in Sources */,
+				4AB577BEF319BC70F4704448 /* AppPreferences.swift in Sources */,
+				D165F0DF1F5F412855970752 /* LanguageUtil.swift in Sources */,
+				1F7BCEF334364CA5750C09C5 /* NotificationName+App.swift in Sources */,
+				155E35F9F4FF3D4EA882D8B7 /* TextUtil.swift in Sources */,
+				39225B597050FA6F4FC4F4EE /* Whis.swift in Sources */,
+				3DA7D955AF233787F177D340 /* WhisperAhead.swift in Sources */,
+				45514FE6BEA916ACB73513F8 /* WhisperAheads.swift in Sources */,
+				4635E0E6E82DC50B9B23DF71 /* WhisperAlignmentHeadsPreset.swift in Sources */,
+				4300B00C93D1591C3D2FDF33 /* WhisperContextParams.swift in Sources */,
+				786D7490994D76CADEC5D845 /* WhisperFullParams.swift in Sources */,
+				F22DDDB0FD8999615A174CFD /* WhisperGrammarElement.swift in Sources */,
+				9B5DE5906BAF005A91B4CDBD /* WhisperGrammarElementType.swift in Sources */,
+				B9E6EBD63F416D4333097320 /* WhisperModelLoader.swift in Sources */,
+				F448117F940452DCB5699D99 /* WhisperSamplingStrategy.swift in Sources */,
+				B5600CC4FCCEF9C28DD1EC66 /* WhisperTimings.swift in Sources */,
+				A444E1B160151034CECF8BCA /* WhisperTokenData.swift in Sources */,
+				808FB8D1CAD6B343AEFC1CA1 /* WhisperModelManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CE57B0242D52C7BB00929AF3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				36EBC1B35882771B03CCEE49 /* (null) in Sources */,
-				36EBC6D475C8352BF3EA9EAF /* (null) in Sources */,
-				36EBC0227428844AC8411325 /* (null) in Sources */,
-				36EBCD229289171650A4E267 /* (null) in Sources */,
-				36EBC8F7DA3F51E4D546612A /* (null) in Sources */,
-				36EBCB7D2726BE5C80C0338A /* (null) in Sources */,
-				36EBCC92099BD2EC03912BC9 /* (null) in Sources */,
-				36EBCE4EA0197EA30ECFA1F7 /* (null) in Sources */,
-				36EBC306D04008635328DAE1 /* (null) in Sources */,
-				36EBCA42DBEDA791E9C785E5 /* (null) in Sources */,
-				36EBCD57CC6B8E2D3FC51EF5 /* (null) in Sources */,
-				36EBC907DA520E4D7D750096 /* (null) in Sources */,
+				36EBC1B35882771B03CCEE49 /* BuildFile in Sources */,
+				36EBC6D475C8352BF3EA9EAF /* BuildFile in Sources */,
+				36EBC0227428844AC8411325 /* BuildFile in Sources */,
+				36EBCD229289171650A4E267 /* BuildFile in Sources */,
+				36EBC8F7DA3F51E4D546612A /* BuildFile in Sources */,
+				36EBCB7D2726BE5C80C0338A /* BuildFile in Sources */,
+				36EBCC92099BD2EC03912BC9 /* BuildFile in Sources */,
+				36EBCE4EA0197EA30ECFA1F7 /* BuildFile in Sources */,
+				36EBC306D04008635328DAE1 /* BuildFile in Sources */,
+				36EBCA42DBEDA791E9C785E5 /* BuildFile in Sources */,
+				36EBCD57CC6B8E2D3FC51EF5 /* BuildFile in Sources */,
+				36EBC907DA520E4D7D750096 /* BuildFile in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -641,6 +965,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		804EAED58FA8C3CF58FB5B5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = WhisperCore;
+			target = FB177DB8D9F479C88750D3E3 /* WhisperCore */;
+			targetProxy = F01A9FF660A6FD86D6B16ECB /* PBXContainerItemProxy */;
+		};
+		CBEC21463E82C81349FC7F65 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = WhisperCore;
+			target = FB177DB8D9F479C88750D3E3 /* WhisperCore */;
+			targetProxy = 7E6E7BECDDF95C71F4E82A41 /* PBXContainerItemProxy */;
+		};
 		CE57B03B2D52C7BC00929AF3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CE57B0272D52C7BB00929AF3 /* OpenSuperWhisper */;
@@ -654,6 +990,125 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		02B38F0E8B8E9513C4FE4A53 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = "OpenSuperWhisper-iOS/OpenSuperWhisper-iOS.entitlements";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libwhisper/whisper.cpp/build-apple",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "OpenSuperWhisper-iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper.ios;
+				PRODUCT_NAME = OpenSuperWhisper;
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		6447E04CDC73F5FF16BE7F6C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libwhisper/whisper.cpp/build-apple",
+				);
+				GCC_OPTIMIZATION_LEVEL = s;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MODULEMAP_FILE = "";
+				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper.WhisperCore;
+				PRODUCT_MODULE_NAME = WhisperCore;
+				PRODUCT_NAME = WhisperCore;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		74A2259DD092A1F11F9B1758 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libwhisper/whisper.cpp/build-apple",
+				);
+				GCC_OPTIMIZATION_LEVEL = 0;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MODULEMAP_FILE = "";
+				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper.WhisperCore;
+				PRODUCT_MODULE_NAME = WhisperCore;
+				PRODUCT_NAME = WhisperCore;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		CE57B04B2D52C7BC00929AF3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -800,12 +1255,10 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/libwhisper/whisper.cpp/build-apple",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/libwhisper/**",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "OpenSuperWhisper/OpenSuperWhisper-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "OpenSuperWhisper needs accessibility access to provide system-wide functionality.";
@@ -819,15 +1272,11 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/build",
-					/opt/homebrew/opt/libomp/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lomp",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -861,13 +1310,11 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/libwhisper/whisper.cpp/build-apple",
 				);
 				GCC_OPTIMIZATION_LEVEL = s;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/libwhisper/**",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "OpenSuperWhisper/OpenSuperWhisper-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "OpenSuperWhisper needs accessibility access to provide system-wide functionality.";
@@ -881,16 +1328,12 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/build",
-					/opt/homebrew/opt/libomp/lib,
 				);
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lomp",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -984,9 +1427,56 @@
 			};
 			name = Release;
 		};
+		FD18D42C21617BAAE54045E6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = "OpenSuperWhisper-iOS/OpenSuperWhisper-iOS.entitlements";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libwhisper/whisper.cpp/build-apple",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "OpenSuperWhisper-iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ru.starmel.OpenSuperWhisper.ios;
+				PRODUCT_NAME = OpenSuperWhisper;
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A959AE174D876C1CC0E3A4D6 /* Build configuration list for PBXNativeTarget "WhisperCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6447E04CDC73F5FF16BE7F6C /* Release */,
+				74A2259DD092A1F11F9B1758 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CCA89AA694CE2BB308E0B858 /* Build configuration list for PBXNativeTarget "OpenSuperWhisper-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD18D42C21617BAAE54045E6 /* Release */,
+				02B38F0E8B8E9513C4FE4A53 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CE57B0232D52C7BB00929AF3 /* Build configuration list for PBXProject "OpenSuperWhisper" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1053,6 +1543,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		B39D0E31B7742ACE6E44AA6B /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE0EAD6C2D56ACA80067FDEE /* XCRemoteSwiftPackageReference "GRDB.swift" */;
+			productName = GRDB;
+		};
 		CE0EAD6D2D56ACA80067FDEE /* GRDB */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CE0EAD6C2D56ACA80067FDEE /* XCRemoteSwiftPackageReference "GRDB.swift" */;

--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1F7BCEF334364CA5750C09C5 /* NotificationName+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365AE4C4A54DDC320C59CB26 /* NotificationName+App.swift */; };
 		212A742687EBECDE4AAE3848 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = B39D0E31B7742ACE6E44AA6B /* GRDB */; };
 		23D98BA308A3C81EFB96B482 /* RecordingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4277DC9C8820065FB0CA5C /* RecordingState.swift */; };
+		2AA533F3A4F1AB9F6F45C83A /* OpenSuperWhisper_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12ACBE3E2E4AED853E94A998 /* OpenSuperWhisper_iOSTests.swift */; };
 		2D4BD27C2D8AF979586D3331 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD8322234219B61A30A56E86 /* Cocoa.framework */; };
 		36EBC0227428844AC8411325 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		36EBC1B35882771B03CCEE49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
@@ -35,6 +36,7 @@
 		4635E0E6E82DC50B9B23DF71 /* WhisperAlignmentHeadsPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E959DEDFBBE8FC1B0818AC0 /* WhisperAlignmentHeadsPreset.swift */; };
 		49E7741E447161F9C1DC374B /* Combine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A5B26C52CF3A537FFFA1693 /* Combine.framework */; };
 		4AB577BEF319BC70F4704448 /* AppPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759B66F8D57252ADAC33A148 /* AppPreferences.swift */; };
+		53E0454EED3ED84F35EB3BD0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED6DD44F3E416801E87F03E0 /* Foundation.framework */; };
 		6713BD2CAFC3EAE6929CDAB6 /* AudioRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BBDDFD41DE1920797A0D38 /* AudioRecording.swift */; };
 		6F77E7BD34BDF0FFCFC48B2E /* Recording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E738DCD057696459BF452F /* Recording.swift */; };
 		70E09C6DD3D2059E3042E031 /* WhisperCore.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -42,6 +44,7 @@
 		808FB8D1CAD6B343AEFC1CA1 /* WhisperModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB257272A13511525877662F /* WhisperModelManager.swift */; };
 		8D9B07107EB29FD4DADB0060 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62764F9A788014838EE43C6D /* iOSApp.swift */; };
 		9422583E9A7FCD1B6F5DA582 /* WhisperEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88876A01106D33F2430307F8 /* WhisperEngine.swift */; };
+		978C5D415DA0536BCE86DCBE /* WhisperCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */; };
 		978EC0BBAF5E34E363F3AAA0 /* TextPostProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174E1385E31A3BABB5941F47 /* TextPostProcessor.swift */; };
 		9B5DE5906BAF005A91B4CDBD /* WhisperGrammarElementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C475147F21DBFA5AEF1203 /* WhisperGrammarElementType.swift */; };
 		A444E1B160151034CECF8BCA /* WhisperTokenData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1570C3627A3C4768F747B88 /* WhisperTokenData.swift */; };
@@ -69,6 +72,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		7AF875BB5E63553021DB36F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE57B0202D52C7BB00929AF3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A27DE96B81CEB6C2F0CB5D6;
+			remoteInfo = "OpenSuperWhisper-iOS";
+		};
 		7E6E7BECDDF95C71F4E82A41 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CE57B0202D52C7BB00929AF3 /* Project object */;
@@ -76,47 +86,12 @@
 			remoteGlobalIDString = FB177DB8D9F479C88750D3E3;
 			remoteInfo = WhisperCore;
 		};
-		840156C42D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
+		99D46137A5E11122B5C300AA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = B8CFD18D1CA64DB288EF4CAB;
-			remoteInfo = ggml;
-		};
-		840156C62D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E9432130077149BEA5672826;
-			remoteInfo = "ggml-base";
-		};
-		840156C82D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E8BC775FB8B44B4FBAD88B47;
-			remoteInfo = "ggml-blas";
-		};
-		840156CA2D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 200441F97DEC455CBF966F1F;
-			remoteInfo = "ggml-cpu";
-		};
-		840156CC2D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F906E52C874462B9841D673;
-			remoteInfo = "ggml-metal";
-		};
-		840156CE2D79ED9900FB5FFE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 30B2BC75387D4C73A3820913;
-			remoteInfo = whisper;
+			containerPortal = CE57B0202D52C7BB00929AF3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB177DB8D9F479C88750D3E3;
+			remoteInfo = WhisperCore;
 		};
 		CE57B03A2D52C7BC00929AF3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -172,8 +147,10 @@
 		01E738DCD057696459BF452F /* Recording.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Recording.swift; sourceTree = "<group>"; };
 		032CA9D8D8107B43FC0F92D6 /* WhisperTimings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperTimings.swift; sourceTree = "<group>"; };
 		0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "libwhisper/whisper.cpp/build-apple/whisper.xcframework"; sourceTree = SOURCE_ROOT; };
+		12ACBE3E2E4AED853E94A998 /* OpenSuperWhisper_iOSTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenSuperWhisper_iOSTests.swift; sourceTree = "<group>"; };
 		174E1385E31A3BABB5941F47 /* TextPostProcessor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextPostProcessor.swift; sourceTree = "<group>"; };
 		20CBEB5746C34EB6FF5E3775 /* ClipboardService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
+		24934981D77B60814485571B /* OpenSuperWhisper-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OpenSuperWhisper-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		25FF761EFBE2052C4B587C7F /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		31C475147F21DBFA5AEF1203 /* WhisperGrammarElementType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperGrammarElementType.swift; sourceTree = "<group>"; };
 		365AE4C4A54DDC320C59CB26 /* NotificationName+App.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NotificationName+App.swift"; sourceTree = "<group>"; };
@@ -188,7 +165,6 @@
 		6B44F50E402A4C4C77712431 /* WhisperAhead.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperAhead.swift; sourceTree = "<group>"; };
 		724CED538D6779C4D2EB0465 /* WhisperFullParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperFullParams.swift; sourceTree = "<group>"; };
 		759B66F8D57252ADAC33A148 /* AppPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppPreferences.swift; sourceTree = "<group>"; };
-		840156402D79E87600FB5FFE /* libwhisper.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libwhisper.xcodeproj; path = libwhisper/build/libwhisper.xcodeproj; sourceTree = "<group>"; };
 		840156592D79EA1A00FB5FFE /* Bridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bridge.h; sourceTree = "<group>"; };
 		88876A01106D33F2430307F8 /* WhisperEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperEngine.swift; sourceTree = "<group>"; };
 		8D888DE3A08A808B2A34ACCA /* OpenSuperWhisper-iOS.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = "OpenSuperWhisper-iOS.entitlements"; sourceTree = "<group>"; };
@@ -227,15 +203,12 @@
 		CE84DF3F2D550BD500C54EA6 /* libggml.dylib.xcent */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = libggml.dylib.xcent; sourceTree = "<group>"; };
 		CE84DF402D550BD500C54EA6 /* libggml.dylib.xcent.der */ = {isa = PBXFileReference; lastKnownFileType = text; path = libggml.dylib.xcent.der; sourceTree = "<group>"; };
 		CE84DF412D550BD500C54EA6 /* Script-8AD8A6185ECD87BB20995F11.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Script-8AD8A6185ECD87BB20995F11.sh"; sourceTree = "<group>"; };
-		CE84DF432D5557F600C54EA6 /* libwhisper.1.7.4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libwhisper.1.7.4.dylib; path = ../../../../usr/local/lib/libwhisper.1.7.4.dylib; sourceTree = "<group>"; };
 		CE84DF462D5557FE00C54EA6 /* libggml-metal.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libggml-metal.dylib"; path = "../../../../usr/local/lib/libggml-metal.dylib"; sourceTree = "<group>"; };
 		CE84DF472D5557FE00C54EA6 /* libggml.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libggml.dylib; path = ../../../../usr/local/lib/libggml.dylib; sourceTree = "<group>"; };
-		CE84DF532D55615600C54EA6 /* libwhisper.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libwhisper.a; path = "../../Library/Developer/Xcode/DerivedData/OpenSuperWhisper-hahlbuibzstrsfgaftshbjlrlesk/SourcePackages/checkouts/whisper.cpp/build/src/libwhisper.a"; sourceTree = "<group>"; };
 		CE84DF632D55762200C54EA6 /* libggml.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libggml.a; sourceTree = "<group>"; };
 		CE84DF642D55762200C54EA6 /* libggml-cpu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libggml-cpu.a"; sourceTree = "<group>"; };
 		CE84DF652D55762200C54EA6 /* libggml-metal.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libggml-metal.a"; sourceTree = "<group>"; };
 		CE84DF662D55762200C54EA6 /* libggml-base.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libggml-base.a"; sourceTree = "<group>"; };
-		CE84DF672D55762200C54EA6 /* libwhisper.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwhisper.a; sourceTree = "<group>"; };
 		CE84DF6D2D55777800C54EA6 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		CE84DF6F2D55778000C54EA6 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		CE84DF702D55778000C54EA6 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
@@ -290,6 +263,15 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4293495FCB9B617108CC0ADC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53E0454EED3ED84F35EB3BD0 /* Foundation.framework in Frameworks */,
+				978C5D415DA0536BCE86DCBE /* WhisperCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8C63CB343341E9D279941C9A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -408,19 +390,6 @@
 			path = WhisperCore;
 			sourceTree = "<group>";
 		};
-		840156412D79E87600FB5FFE /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				840156C52D79ED9900FB5FFE /* libggml.a */,
-				840156C72D79ED9900FB5FFE /* libggml-base.a */,
-				840156C92D79ED9900FB5FFE /* libggml-blas.a */,
-				840156CB2D79ED9900FB5FFE /* libggml-cpu.a */,
-				840156CD2D79ED9900FB5FFE /* libggml-metal.a */,
-				840156CF2D79ED9900FB5FFE /* libwhisper.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		CE37B60E2D54F274009D6564 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -429,15 +398,12 @@
 				CE84DF6F2D55778000C54EA6 /* Metal.framework */,
 				CE84DF702D55778000C54EA6 /* MetalKit.framework */,
 				CE84DF6D2D55777800C54EA6 /* libc++.tbd */,
-				CE84DF532D55615600C54EA6 /* libwhisper.a */,
 				CE84DF632D55762200C54EA6 /* libggml.a */,
 				CE84DF662D55762200C54EA6 /* libggml-base.a */,
 				CE84DF642D55762200C54EA6 /* libggml-cpu.a */,
 				CE84DF652D55762200C54EA6 /* libggml-metal.a */,
-				CE84DF672D55762200C54EA6 /* libwhisper.a */,
 				CE84DF472D5557FE00C54EA6 /* libggml.dylib */,
 				CE84DF462D5557FE00C54EA6 /* libggml-metal.dylib */,
-				CE84DF432D5557F600C54EA6 /* libwhisper.1.7.4.dylib */,
 				CE84DF422D550BD500C54EA6 /* Release-iphoneos */,
 				CE84DF332D550BB400C54EA6 /* ggml.build */,
 				5F967FBB424C7B4B2F433212 /* OS X */,
@@ -453,7 +419,6 @@
 			isa = PBXGroup;
 			children = (
 				840156592D79EA1A00FB5FFE /* Bridge.h */,
-				840156402D79E87600FB5FFE /* libwhisper.xcodeproj */,
 				CE57B02A2D52C7BB00929AF3 /* OpenSuperWhisper */,
 				CE57B03C2D52C7BC00929AF3 /* OpenSuperWhisperTests */,
 				CE57B0462D52C7BC00929AF3 /* OpenSuperWhisperUITests */,
@@ -465,6 +430,7 @@
 				6230A80D984CFC89A507FF51 /* WhisperCore */,
 				0C4F55605FEDEA305BF6DA48 /* whisper.xcframework */,
 				E42651422955BD6D714FF96F /* OpenSuperWhisper-iOS */,
+				FF78EBCA005F61DDE3C1827F /* OpenSuperWhisper-iOSTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -476,6 +442,7 @@
 				CE57B0432D52C7BC00929AF3 /* OpenSuperWhisperUITests.xctest */,
 				B1AF28BDBE6D7A5704A2E30B /* WhisperCore.framework */,
 				FD661BC69E117292731461C5 /* OpenSuperWhisper-iOS.app */,
+				24934981D77B60814485571B /* OpenSuperWhisper-iOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -624,6 +591,15 @@
 			path = Engines;
 			sourceTree = "<group>";
 		};
+		FF78EBCA005F61DDE3C1827F /* OpenSuperWhisper-iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				12ACBE3E2E4AED853E94A998 /* OpenSuperWhisper_iOSTests.swift */,
+			);
+			name = "OpenSuperWhisper-iOSTests";
+			path = "OpenSuperWhisper-iOSTests";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -725,6 +701,25 @@
 			productReference = CE57B0432D52C7BC00929AF3 /* OpenSuperWhisperUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		CF2BDE29413ADE841A3B1E14 /* OpenSuperWhisper-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 55F85E28A3C5A4706FE27BDE /* Build configuration list for PBXNativeTarget "OpenSuperWhisper-iOSTests" */;
+			buildPhases = (
+				B15D5ED0BB7AF43D97535E95 /* Sources */,
+				4293495FCB9B617108CC0ADC /* Frameworks */,
+				E515FE4372AD3ED8F625AB59 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				23CADC129924A21CBFDF5F58 /* PBXTargetDependency */,
+				9B64599C6A654ABA7267B277 /* PBXTargetDependency */,
+			);
+			name = "OpenSuperWhisper-iOSTests";
+			productName = "OpenSuperWhisper-iOSTests";
+			productReference = 24934981D77B60814485571B /* OpenSuperWhisper-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		FB177DB8D9F479C88750D3E3 /* WhisperCore */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A959AE174D876C1CC0E3A4D6 /* Build configuration list for PBXNativeTarget "WhisperCore" */;
@@ -786,12 +781,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CE57B0292D52C7BB00929AF3 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 840156412D79E87600FB5FFE /* Products */;
-					ProjectRef = 840156402D79E87600FB5FFE /* libwhisper.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				CE57B0272D52C7BB00929AF3 /* OpenSuperWhisper */,
@@ -799,54 +788,10 @@
 				CE57B0422D52C7BC00929AF3 /* OpenSuperWhisperUITests */,
 				FB177DB8D9F479C88750D3E3 /* WhisperCore */,
 				8A27DE96B81CEB6C2F0CB5D6 /* OpenSuperWhisper-iOS */,
+				CF2BDE29413ADE841A3B1E14 /* OpenSuperWhisper-iOSTests */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		840156C52D79ED9900FB5FFE /* libggml.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libggml.a;
-			remoteRef = 840156C42D79ED9900FB5FFE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		840156C72D79ED9900FB5FFE /* libggml-base.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libggml-base.a";
-			remoteRef = 840156C62D79ED9900FB5FFE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		840156C92D79ED9900FB5FFE /* libggml-blas.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libggml-blas.a";
-			remoteRef = 840156C82D79ED9900FB5FFE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		840156CB2D79ED9900FB5FFE /* libggml-cpu.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libggml-cpu.a";
-			remoteRef = 840156CA2D79ED9900FB5FFE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		840156CD2D79ED9900FB5FFE /* libggml-metal.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libggml-metal.a";
-			remoteRef = 840156CC2D79ED9900FB5FFE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		840156CF2D79ED9900FB5FFE /* libwhisper.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libwhisper.a;
-			remoteRef = 840156CE2D79ED9900FB5FFE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		CE57B0262D52C7BB00929AF3 /* Resources */ = {
@@ -864,6 +809,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CE57B0412D52C7BC00929AF3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E515FE4372AD3ED8F625AB59 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -892,6 +844,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D9B07107EB29FD4DADB0060 /* iOSApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B15D5ED0BB7AF43D97535E95 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2AA533F3A4F1AB9F6F45C83A /* OpenSuperWhisper_iOSTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -965,11 +925,23 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		23CADC129924A21CBFDF5F58 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "OpenSuperWhisper-iOS";
+			target = 8A27DE96B81CEB6C2F0CB5D6 /* OpenSuperWhisper-iOS */;
+			targetProxy = 7AF875BB5E63553021DB36F1 /* PBXContainerItemProxy */;
+		};
 		804EAED58FA8C3CF58FB5B5D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = WhisperCore;
 			target = FB177DB8D9F479C88750D3E3 /* WhisperCore */;
 			targetProxy = F01A9FF660A6FD86D6B16ECB /* PBXContainerItemProxy */;
+		};
+		9B64599C6A654ABA7267B277 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = WhisperCore;
+			target = FB177DB8D9F479C88750D3E3 /* WhisperCore */;
+			targetProxy = 99D46137A5E11122B5C300AA /* PBXContainerItemProxy */;
 		};
 		CBEC21463E82C81349FC7F65 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1017,6 +989,26 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		218B018E00AEAF2D5DEE60F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.starmel.OpenSuperWhisper-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OpenSuperWhisper-iOS.app/OpenSuperWhisper-iOS";
 			};
 			name = Debug;
 		};
@@ -1460,9 +1452,39 @@
 			};
 			name = Release;
 		};
+		FEC3812C2157DFB3974853A6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.starmel.OpenSuperWhisper-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OpenSuperWhisper-iOS.app/OpenSuperWhisper-iOS";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		55F85E28A3C5A4706FE27BDE /* Build configuration list for PBXNativeTarget "OpenSuperWhisper-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FEC3812C2157DFB3974853A6 /* Release */,
+				218B018E00AEAF2D5DEE60F8 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A959AE174D876C1CC0E3A4D6 /* Build configuration list for PBXNativeTarget "WhisperCore" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/OpenSuperWhisper/AudioRecorder.swift
+++ b/OpenSuperWhisper/AudioRecorder.swift
@@ -3,14 +3,19 @@ import Foundation
 import SwiftUI
 import AppKit
 import CoreAudio
+import WhisperCore
 
-class AudioRecorder: NSObject, ObservableObject {
+class AudioRecorder: NSObject, ObservableObject, AudioRecording {
     @Published var isRecording = false
     @Published var isPlaying = false
     @Published var currentlyPlayingURL: URL?
     @Published var canRecord = false
     @Published var isConnecting = false
-    
+
+    var currentTime: TimeInterval {
+        audioRecorder?.currentTime ?? 0
+    }
+
     private var audioRecorder: AVAudioRecorder?
     private var audioPlayer: AVAudioPlayer?
     private var notificationSound: NSSound?

--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -10,6 +10,7 @@ import Combine
 import KeyboardShortcuts
 import SwiftUI
 import UniformTypeIdentifiers
+import WhisperCore
 
 @MainActor
 class ContentViewModel: ObservableObject {

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import FluidAudio
+import WhisperCore
 
 class FluidAudioEngine: TranscriptionEngine {
     var engineName: String { "FluidAudio" }
@@ -29,7 +30,7 @@ class FluidAudioEngine: TranscriptionEngine {
         asrModels = models
     }
     
-    func transcribeAudio(url: URL, settings: Settings) async throws -> String {
+    func transcribeAudio(url: URL, settings: TranscriptionSettings) async throws -> String {
         guard let asrManager = asrManager else {
             throw TranscriptionError.contextInitializationFailed
         }

--- a/OpenSuperWhisper/FileDropHandler.swift
+++ b/OpenSuperWhisper/FileDropHandler.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
 import AVFoundation
+import WhisperCore
 
 @MainActor
 class FileDropHandler: ObservableObject {

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -1,14 +1,7 @@
 import Cocoa
 import Combine
 import SwiftUI
-
-enum RecordingState {
-    case idle
-    case connecting
-    case recording
-    case decoding
-    case busy
-}
+import WhisperCore
 
 @MainActor
 protocol IndicatorViewDelegate: AnyObject {

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Foundation
 import Combine
 import CoreAudio
+import WhisperCore
 
 class MicrophoneService: ObservableObject {
     static let shared = MicrophoneService()

--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import FluidAudio
+import WhisperCore
 
 enum OnboardingShortcutOption: String, CaseIterable {
     case keyCombination

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import AppKit
 import Combine
 import UniformTypeIdentifiers
+import WhisperCore
 
 @main
 struct OpenSuperWhisperApp: App {
@@ -51,6 +52,7 @@ struct OpenSuperWhisperApp: App {
         _ = ShortcutManager.shared
         _ = MicrophoneService.shared
         WhisperModelManager.shared.ensureDefaultModelPresent()
+        TranscriptionService.shared.textPostProcessor = AutocorrectPostProcessor()
     }
 }
 

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -53,6 +53,7 @@ struct OpenSuperWhisperApp: App {
         _ = MicrophoneService.shared
         WhisperModelManager.shared.ensureDefaultModelPresent()
         TranscriptionService.shared.textPostProcessor = AutocorrectPostProcessor()
+        TranscriptionService.shared.alternateEngineFactory = { FluidAudioEngine() }
     }
 }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -5,6 +5,7 @@ import Foundation
 import KeyboardShortcuts
 import SwiftUI
 import FluidAudio
+import WhisperCore
 
 class SettingsViewModel: ObservableObject {
     @Published var selectedEngine: String {
@@ -481,42 +482,7 @@ struct SettingsDownloadableModels {
     ]
 }
 
-struct Settings {
-    static let asianLanguages: Set<String> = ["zh", "ja", "ko"]
-    
-    var selectedLanguage: String
-    var translateToEnglish: Bool
-    var suppressBlankAudio: Bool
-    var showTimestamps: Bool
-    var temperature: Double
-    var noSpeechThreshold: Double
-    var initialPrompt: String
-    var useBeamSearch: Bool
-    var beamSize: Int
-    var useAsianAutocorrect: Bool
-    
-    var isAsianLanguage: Bool {
-        Settings.asianLanguages.contains(selectedLanguage)
-    }
-    
-    var shouldApplyAsianAutocorrect: Bool {
-        isAsianLanguage && useAsianAutocorrect
-    }
-    
-    init() {
-        let prefs = AppPreferences.shared
-        self.selectedLanguage = prefs.whisperLanguage
-        self.translateToEnglish = prefs.translateToEnglish
-        self.suppressBlankAudio = prefs.suppressBlankAudio
-        self.showTimestamps = prefs.showTimestamps
-        self.temperature = prefs.temperature
-        self.noSpeechThreshold = prefs.noSpeechThreshold
-        self.initialPrompt = prefs.initialPrompt
-        self.useBeamSearch = prefs.useBeamSearch
-        self.beamSize = prefs.beamSize
-        self.useAsianAutocorrect = prefs.useAsianAutocorrect
-    }
-}
+typealias Settings = TranscriptionSettings
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -5,6 +5,7 @@ import Cocoa
 import Foundation
 import KeyboardShortcuts
 import SwiftUI
+import WhisperCore
 
 extension KeyboardShortcuts.Name {
     static let toggleRecord = Self("toggleRecord", default: .init(.backtick, modifiers: .option))

--- a/OpenSuperWhisper/Utils/AutocorrectPostProcessor.swift
+++ b/OpenSuperWhisper/Utils/AutocorrectPostProcessor.swift
@@ -1,0 +1,8 @@
+import Foundation
+import WhisperCore
+
+struct AutocorrectPostProcessor: TextPostProcessor {
+    func process(_ text: String, language: String) -> String {
+        AutocorrectWrapper.format(text)
+    }
+}

--- a/OpenSuperWhisper/Utils/ClipboardUtil.swift
+++ b/OpenSuperWhisper/Utils/ClipboardUtil.swift
@@ -1,8 +1,20 @@
 import Cocoa
 import ApplicationServices
 import Carbon
+import WhisperCore
 
-class ClipboardUtil {
+class ClipboardUtil: ClipboardService {
+
+    func copyToClipboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString(text, forType: .string)
+    }
+
+    func getClipboardText() -> String? {
+        NSPasteboard.general.string(forType: .string)
+    }
+
     
     static func insertText(_ text: String) {
         let pasteboard = NSPasteboard.general

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1101,3 +1101,137 @@ final class TextUtilTests: XCTestCase {
         XCTAssertEqual(TextUtil.formatDuration(3600), "1h 0m 0s")
     }
 }
+
+// MARK: - NoOpTextPostProcessor Tests
+
+final class NoOpTextPostProcessorTests: XCTestCase {
+    func testReturnsInputUnchanged() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertEqual(processor.process("hello world", language: "en"), "hello world")
+    }
+
+    func testReturnsEmptyStringUnchanged() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertEqual(processor.process("", language: "en"), "")
+    }
+
+    func testReturnsUnicodeUnchanged() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertEqual(processor.process("こんにちは世界", language: "ja"), "こんにちは世界")
+    }
+}
+
+// MARK: - TranscriptionSettings Computed Property Tests
+
+final class TranscriptionSettingsComputedPropertyTests: XCTestCase {
+    func testIsAsianLanguage_japanese() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ja"
+        XCTAssertTrue(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_chinese() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "zh"
+        XCTAssertTrue(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_korean() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ko"
+        XCTAssertTrue(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_english() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "en"
+        XCTAssertFalse(settings.isAsianLanguage)
+    }
+
+    func testIsAsianLanguage_auto() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "auto"
+        XCTAssertFalse(settings.isAsianLanguage)
+    }
+
+    func testShouldApplyAsianAutocorrect_asianWithAutocorrectOn() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ja"
+        settings.useAsianAutocorrect = true
+        XCTAssertTrue(settings.shouldApplyAsianAutocorrect)
+    }
+
+    func testShouldApplyAsianAutocorrect_asianWithAutocorrectOff() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "ja"
+        settings.useAsianAutocorrect = false
+        XCTAssertFalse(settings.shouldApplyAsianAutocorrect)
+    }
+
+    func testShouldApplyAsianAutocorrect_nonAsianWithAutocorrectOn() {
+        var settings = TranscriptionSettings()
+        settings.selectedLanguage = "en"
+        settings.useAsianAutocorrect = true
+        XCTAssertFalse(settings.shouldApplyAsianAutocorrect)
+    }
+
+    func testAsianLanguagesSet() {
+        XCTAssertEqual(TranscriptionSettings.asianLanguages, Set(["zh", "ja", "ko"]))
+    }
+}
+
+// MARK: - Protocol Conformance Tests
+
+final class ProtocolConformanceTests: XCTestCase {
+    func testAudioRecorderConformsToAudioRecording() {
+        let recorder = AudioRecorder.shared
+        XCTAssertTrue(recorder is AudioRecording, "AudioRecorder should conform to AudioRecording protocol")
+    }
+
+    func testClipboardUtilConformsToClipboardService() {
+        let clipboard = ClipboardUtil()
+        XCTAssertTrue(clipboard is ClipboardService, "ClipboardUtil should conform to ClipboardService protocol")
+    }
+
+    func testAutocorrectPostProcessorConformsToTextPostProcessor() {
+        let processor = AutocorrectPostProcessor()
+        XCTAssertTrue(processor is TextPostProcessor, "AutocorrectPostProcessor should conform to TextPostProcessor protocol")
+    }
+
+    func testNoOpTextPostProcessorConformsToTextPostProcessor() {
+        let processor = NoOpTextPostProcessor()
+        XCTAssertTrue(processor is TextPostProcessor, "NoOpTextPostProcessor should conform to TextPostProcessor protocol")
+    }
+}
+
+// MARK: - TranscriptionService DI Tests
+
+@MainActor
+final class TranscriptionServiceDITests: XCTestCase {
+    func testDefaultTextPostProcessorIsNoOp() {
+        let service = TranscriptionService()
+        let processor = service.textPostProcessor
+        // Default should be NoOpTextPostProcessor — verify by checking passthrough behavior
+        XCTAssertEqual(processor.process("test input", language: "en"), "test input")
+        XCTAssertEqual(processor.process("日本語テスト", language: "ja"), "日本語テスト")
+    }
+
+    func testDefaultAlternateEngineFactoryIsNil() {
+        let service = TranscriptionService()
+        XCTAssertNil(service.alternateEngineFactory)
+    }
+
+    func testTextPostProcessorCanBeSwapped() {
+        let service = TranscriptionService()
+        let customProcessor = AutocorrectPostProcessor()
+        service.textPostProcessor = customProcessor
+        XCTAssertTrue(service.textPostProcessor is AutocorrectPostProcessor)
+    }
+
+    func testAlternateEngineFactoryCanBeSet() {
+        let service = TranscriptionService()
+        XCTAssertNil(service.alternateEngineFactory)
+        service.alternateEngineFactory = { nil }
+        XCTAssertNotNil(service.alternateEngineFactory)
+    }
+}

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -10,6 +10,7 @@ import Carbon
 import ApplicationServices
 import AVFoundation
 @testable import OpenSuperWhisper
+import WhisperCore
 
 final class OpenSuperWhisperTests: XCTestCase {
 

--- a/Scripts/build-xcframework.sh
+++ b/Scripts/build-xcframework.sh
@@ -19,7 +19,7 @@
 #   - Separate per-arch builds with lipo for simulator fat binary
 #
 
-set -e
+set -eo pipefail
 
 # ----- Configuration -----
 IOS_MIN_OS_VERSION=17.0

--- a/Scripts/build-xcframework.sh
+++ b/Scripts/build-xcframework.sh
@@ -115,12 +115,18 @@ build_arch() {
         extra_args+=(-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT="${sdk_path}")
     fi
 
-    cmake -B "${build_dir}" \
+    local cmake_output
+    cmake_output=$(cmake -B "${build_dir}" \
         "${COMMON_CMAKE_ARGS[@]}" \
         "${extra_args[@]}" \
         -DCMAKE_OSX_DEPLOYMENT_TARGET="${deployment_target}" \
         -DCMAKE_OSX_ARCHITECTURES="${arch}" \
-        -S . 2>&1 | grep -E "(error|Error|Including|Configuring done)" || true
+        -S . 2>&1) || {
+        echo "Error: cmake configure failed for ${build_dir} (${arch})"
+        echo "$cmake_output"
+        exit 1
+    }
+    echo "$cmake_output" | grep -E "(error|Error|Including|Configuring done)" || true
 
     echo "  Building ${build_dir} (${arch})..."
     cmake --build "${build_dir}" -j "${JOBS}" 2>&1 | tail -3
@@ -328,7 +334,7 @@ create_dynamic_lib() {
 
     # Mark device builds with correct platform version
     if [[ "$is_simulator" == "false" && "$platform" == "ios" ]]; then
-        if xcrun -f vtool &>/dev/null 2>&1; then
+        if xcrun -f vtool &>/dev/null; then
             echo "  Marking binary for iOS device..."
             xcrun vtool -set-build-version ios ${IOS_MIN_OS_VERSION} ${IOS_MIN_OS_VERSION} -replace \
                 -output "${output_lib}" "${output_lib}"

--- a/Scripts/build-xcframework.sh
+++ b/Scripts/build-xcframework.sh
@@ -1,0 +1,507 @@
+#!/bin/bash
+#
+# Build whisper.xcframework for macOS + iOS (device + simulator)
+#
+# Produces a 3-slice dynamic xcframework:
+#   1. macOS arm64
+#   2. iOS device arm64
+#   3. iOS simulator arm64 + x86_64
+#
+# Output: libwhisper/whisper.cpp/build-apple/whisper.xcframework
+#
+# Adapted from upstream whisper.cpp/build-xcframework.sh with these changes:
+#   - Only 3 slices (no visionOS, tvOS)
+#   - CoreML OFF (ADR-002)
+#   - OpenMP OFF for all slices (ADR-008)
+#   - iOS deployment target 17.0, macOS 14.0
+#   - macOS arm64 only (Apple Silicon, matching project convention)
+#   - Uses Unix Makefiles generator (Xcode generator broken with CMake 4.x + Xcode 26)
+#   - Separate per-arch builds with lipo for simulator fat binary
+#
+
+set -e
+
+# ----- Configuration -----
+IOS_MIN_OS_VERSION=17.0
+MACOS_MIN_OS_VERSION=14.0
+
+# Metal GPU acceleration
+GGML_METAL=ON
+GGML_METAL_EMBED_LIBRARY=ON
+GGML_METAL_USE_BF16=ON
+GGML_BLAS_DEFAULT=ON
+
+# Disabled features (ADR decisions)
+GGML_OPENMP=OFF      # ADR-008: OFF for all slices
+WHISPER_COREML=OFF    # ADR-002: CoreML deferred
+
+COMMON_C_FLAGS="-Wno-macro-redefined -Wno-shorten-64-to-32 -Wno-unused-command-line-argument -g"
+COMMON_CXX_FLAGS="-Wno-macro-redefined -Wno-shorten-64-to-32 -Wno-unused-command-line-argument -g"
+
+# Parallel jobs for make
+JOBS=$(sysctl -n hw.ncpu 2>/dev/null || echo 8)
+
+# ----- Resolve paths -----
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WHISPER_DIR="${PROJECT_ROOT}/libwhisper/whisper.cpp"
+
+if [ ! -f "${WHISPER_DIR}/CMakeLists.txt" ]; then
+    echo "Error: whisper.cpp submodule not found at ${WHISPER_DIR}"
+    echo "Run: git submodule update --init --recursive"
+    exit 1
+fi
+
+cd "${WHISPER_DIR}"
+echo "Working directory: $(pwd)"
+
+# ----- Tool checks -----
+check_required_tool() {
+    local tool=$1
+    local install_message=$2
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: $tool is required but not found."
+        echo "$install_message"
+        exit 1
+    fi
+}
+
+echo "Checking required tools..."
+check_required_tool "cmake" "Please install CMake 3.28.0 or later (brew install cmake)"
+check_required_tool "xcodebuild" "Please install Xcode and Xcode Command Line Tools (xcode-select --install)"
+check_required_tool "libtool" "Should be available with Xcode Command Line Tools (xcode-select --install)"
+check_required_tool "dsymutil" "Should be available with Xcode Command Line Tools (xcode-select --install)"
+check_required_tool "lipo" "Should be available with Xcode Command Line Tools (xcode-select --install)"
+
+echo "Detected Xcode: $(xcodebuild -version 2>/dev/null | head -n1)"
+echo "Detected CMake: $(cmake --version | head -n1)"
+
+# ----- Common CMake args -----
+# Note: Uses Unix Makefiles instead of Xcode generator for compatibility
+# with CMake 4.x + Xcode 26.x. Per-arch builds with lipo for fat binaries.
+COMMON_CMAKE_ARGS=(
+    -G "Unix Makefiles"
+    -DCMAKE_BUILD_TYPE=Release
+    -DBUILD_SHARED_LIBS=OFF
+    -DWHISPER_BUILD_EXAMPLES=OFF
+    -DWHISPER_BUILD_TESTS=OFF
+    -DWHISPER_BUILD_SERVER=OFF
+    -DGGML_METAL_EMBED_LIBRARY=${GGML_METAL_EMBED_LIBRARY}
+    -DGGML_BLAS_DEFAULT=${GGML_BLAS_DEFAULT}
+    -DGGML_METAL=${GGML_METAL}
+    -DGGML_METAL_USE_BF16=${GGML_METAL_USE_BF16}
+    -DGGML_NATIVE=OFF
+    -DGGML_OPENMP=${GGML_OPENMP}
+    -DWHISPER_COREML=${WHISPER_COREML}
+    -DCMAKE_C_FLAGS="${COMMON_C_FLAGS}"
+    -DCMAKE_CXX_FLAGS="${COMMON_CXX_FLAGS}"
+)
+
+# ----- Build a single arch -----
+# Usage: build_arch <build_dir> <system_name> <sdk_name> <arch> <deployment_target>
+build_arch() {
+    local build_dir=$1
+    local system_name=$2  # "Darwin" for macOS, "iOS" for iOS
+    local sdk_name=$3     # "macosx", "iphoneos", "iphonesimulator"
+    local arch=$4
+    local deployment_target=$5
+
+    echo "  Configuring ${build_dir} (${arch})..."
+    local sdk_path
+    sdk_path="$(xcrun --sdk "${sdk_name}" --show-sdk-path)"
+
+    local extra_args=()
+    if [[ "$system_name" == "iOS" ]]; then
+        extra_args+=(-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT="${sdk_path}")
+    fi
+
+    cmake -B "${build_dir}" \
+        "${COMMON_CMAKE_ARGS[@]}" \
+        "${extra_args[@]}" \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="${deployment_target}" \
+        -DCMAKE_OSX_ARCHITECTURES="${arch}" \
+        -S . 2>&1 | grep -E "(error|Error|Including|Configuring done)" || true
+
+    echo "  Building ${build_dir} (${arch})..."
+    cmake --build "${build_dir}" -j "${JOBS}" 2>&1 | tail -3
+}
+
+# ----- Collect static libs from a build dir -----
+collect_static_libs() {
+    local build_dir=$1
+    local base_dir="$(pwd)"
+
+    local libs=(
+        "${base_dir}/${build_dir}/src/libwhisper.a"
+        "${base_dir}/${build_dir}/ggml/src/libggml.a"
+        "${base_dir}/${build_dir}/ggml/src/libggml-base.a"
+        "${base_dir}/${build_dir}/ggml/src/libggml-cpu.a"
+        "${base_dir}/${build_dir}/ggml/src/ggml-metal/libggml-metal.a"
+        "${base_dir}/${build_dir}/ggml/src/ggml-blas/libggml-blas.a"
+    )
+
+    # Verify all libs exist
+    for lib in "${libs[@]}"; do
+        if [ ! -f "$lib" ]; then
+            echo "Error: Expected static library not found: $lib"
+            exit 1
+        fi
+    done
+
+    echo "${libs[@]}"
+}
+
+# ----- Framework structure setup -----
+setup_framework_structure() {
+    local framework_dir=$1
+    local min_os_version=$2
+    local platform=$3  # "ios" or "macos"
+    local framework_name="whisper"
+
+    echo "  Creating ${platform} framework structure..."
+
+    if [[ "$platform" == "macos" ]]; then
+        mkdir -p "${framework_dir}/Versions/A/Headers"
+        mkdir -p "${framework_dir}/Versions/A/Modules"
+        mkdir -p "${framework_dir}/Versions/A/Resources"
+
+        ln -sf A "${framework_dir}/Versions/Current"
+        ln -sf Versions/Current/Headers "${framework_dir}/Headers"
+        ln -sf Versions/Current/Modules "${framework_dir}/Modules"
+        ln -sf Versions/Current/Resources "${framework_dir}/Resources"
+        ln -sf "Versions/Current/${framework_name}" "${framework_dir}/${framework_name}"
+
+        local header_path="${framework_dir}/Versions/A/Headers"
+        local module_path="${framework_dir}/Versions/A/Modules"
+    else
+        mkdir -p "${framework_dir}/Headers"
+        mkdir -p "${framework_dir}/Modules"
+        rm -rf "${framework_dir}/Versions"
+
+        local header_path="${framework_dir}/Headers"
+        local module_path="${framework_dir}/Modules"
+    fi
+
+    # Copy headers
+    cp include/whisper.h           "${header_path}/"
+    cp ggml/include/ggml.h         "${header_path}/"
+    cp ggml/include/ggml-alloc.h   "${header_path}/"
+    cp ggml/include/ggml-backend.h "${header_path}/"
+    cp ggml/include/ggml-metal.h   "${header_path}/"
+    cp ggml/include/ggml-cpu.h     "${header_path}/"
+    cp ggml/include/ggml-blas.h    "${header_path}/"
+    cp ggml/include/gguf.h         "${header_path}/"
+
+    # Module map for Swift import
+    cat > "${module_path}/module.modulemap" << 'MODULEMAP'
+framework module whisper {
+    header "whisper.h"
+    header "ggml.h"
+    header "ggml-alloc.h"
+    header "ggml-backend.h"
+    header "ggml-metal.h"
+    header "ggml-cpu.h"
+    header "ggml-blas.h"
+    header "gguf.h"
+
+    link "c++"
+    link framework "Accelerate"
+    link framework "Metal"
+    link framework "Foundation"
+
+    export *
+}
+MODULEMAP
+
+    # Info.plist
+    local platform_name=""
+    local sdk_name=""
+    local supported_platform=""
+    local plist_path=""
+    local device_family=""
+
+    case "$platform" in
+        "ios")
+            platform_name="iphoneos"
+            sdk_name="iphoneos${min_os_version}"
+            supported_platform="iPhoneOS"
+            plist_path="${framework_dir}/Info.plist"
+            device_family='    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>'
+            ;;
+        "macos")
+            platform_name="macosx"
+            sdk_name="macosx${min_os_version}"
+            supported_platform="MacOSX"
+            plist_path="${framework_dir}/Versions/A/Resources/Info.plist"
+            device_family=""
+            ;;
+    esac
+
+    cat > "${plist_path}" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>whisper</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.ggml.whisper</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>whisper</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>${min_os_version}</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>${supported_platform}</string>
+    </array>${device_family}
+    <key>DTPlatformName</key>
+    <string>${platform_name}</string>
+    <key>DTSDKName</key>
+    <string>${sdk_name}</string>
+</dict>
+</plist>
+EOF
+}
+
+# ----- Create dynamic library from static libs -----
+# Usage: create_dynamic_lib <combined_a> <output_lib> <dsym_dir> <platform> <is_simulator> <archs...>
+create_dynamic_lib() {
+    local combined_a=$1
+    local output_lib=$2
+    local dsym_dir=$3
+    local platform=$4
+    local is_simulator=$5
+    shift 5
+    local archs=("$@")
+
+    local sdk=""
+    local min_version_flag=""
+    local install_name=""
+    local frameworks="-framework Foundation -framework Metal -framework Accelerate"
+
+    case "$platform" in
+        "ios")
+            if [[ "$is_simulator" == "true" ]]; then
+                sdk="iphonesimulator"
+                min_version_flag="-mios-simulator-version-min=${IOS_MIN_OS_VERSION}"
+            else
+                sdk="iphoneos"
+                min_version_flag="-mios-version-min=${IOS_MIN_OS_VERSION}"
+            fi
+            install_name="@rpath/whisper.framework/whisper"
+            ;;
+        "macos")
+            sdk="macosx"
+            min_version_flag="-mmacosx-version-min=${MACOS_MIN_OS_VERSION}"
+            install_name="@rpath/whisper.framework/Versions/Current/whisper"
+            ;;
+    esac
+
+    local arch_flags=""
+    for arch in "${archs[@]}"; do
+        arch_flags+=" -arch $arch"
+    done
+
+    echo "  Linking dynamic library (${archs[*]})..."
+    xcrun -sdk "$sdk" clang++ -dynamiclib \
+        -isysroot "$(xcrun --sdk "$sdk" --show-sdk-path)" \
+        $arch_flags \
+        $min_version_flag \
+        -Wl,-force_load,"${combined_a}" \
+        $frameworks \
+        -install_name "$install_name" \
+        -o "${output_lib}"
+
+    # Mark device builds with correct platform version
+    if [[ "$is_simulator" == "false" && "$platform" == "ios" ]]; then
+        if xcrun -f vtool &>/dev/null 2>&1; then
+            echo "  Marking binary for iOS device..."
+            xcrun vtool -set-build-version ios ${IOS_MIN_OS_VERSION} ${IOS_MIN_OS_VERSION} -replace \
+                -output "${output_lib}" "${output_lib}"
+        else
+            echo "  Warning: vtool not found. Binary may not pass App Store validation."
+        fi
+    fi
+
+    # Generate dSYM
+    mkdir -p "${dsym_dir}"
+    echo "  Generating dSYM..."
+    xcrun dsymutil "${output_lib}" -o "${dsym_dir}/whisper.dSYM"
+
+    # Strip debug symbols from the binary
+    local temp_stripped="${output_lib}.stripped"
+    xcrun strip -S "${output_lib}" -o "${temp_stripped}"
+    mv "${temp_stripped}" "${output_lib}"
+
+    # Remove any auto-generated dSYM in framework structure
+    if [ -d "${output_lib}.dSYM" ]; then
+        rm -rf "${output_lib}.dSYM"
+    fi
+}
+
+# ===== BUILD =====
+
+echo ""
+echo "=========================================="
+echo "Building whisper.xcframework"
+echo "  macOS ${MACOS_MIN_OS_VERSION} (arm64)"
+echo "  iOS ${IOS_MIN_OS_VERSION} (device arm64)"
+echo "  iOS ${IOS_MIN_OS_VERSION} (simulator arm64+x86_64)"
+echo "  Metal: ON, CoreML: OFF, OpenMP: OFF"
+echo "=========================================="
+echo ""
+
+# Clean previous builds (idempotent)
+echo "Cleaning previous builds..."
+rm -rf build-apple
+rm -rf build-ios-sim-arm64
+rm -rf build-ios-sim-x86_64
+rm -rf build-ios-device
+rm -rf build-macos
+
+# ----- 1. iOS Simulator arm64 -----
+echo ""
+echo "[1/4] iOS Simulator (arm64)..."
+build_arch "build-ios-sim-arm64" "iOS" "iphonesimulator" "arm64" "${IOS_MIN_OS_VERSION}"
+
+# ----- 2. iOS Simulator x86_64 -----
+echo ""
+echo "[2/4] iOS Simulator (x86_64)..."
+build_arch "build-ios-sim-x86_64" "iOS" "iphonesimulator" "x86_64" "${IOS_MIN_OS_VERSION}"
+
+# ----- 3. iOS Device arm64 -----
+echo ""
+echo "[3/4] iOS Device (arm64)..."
+build_arch "build-ios-device" "iOS" "iphoneos" "arm64" "${IOS_MIN_OS_VERSION}"
+
+# ----- 4. macOS arm64 -----
+echo ""
+echo "[4/4] macOS (arm64)..."
+build_arch "build-macos" "Darwin" "macosx" "arm64" "${MACOS_MIN_OS_VERSION}"
+
+# ----- Combine simulator architectures with lipo -----
+echo ""
+echo "Combining simulator architectures..."
+BASE_DIR="$(pwd)"
+
+# Collect lib names from one of the sim builds
+SIM_ARM64_LIBS=($(collect_static_libs "build-ios-sim-arm64"))
+SIM_X86_LIBS=($(collect_static_libs "build-ios-sim-x86_64"))
+
+mkdir -p build-ios-sim-fat/src
+mkdir -p build-ios-sim-fat/ggml/src/ggml-metal
+mkdir -p build-ios-sim-fat/ggml/src/ggml-blas
+
+# lipo each lib pair into a fat binary
+LIB_NAMES=("src/libwhisper.a" "ggml/src/libggml.a" "ggml/src/libggml-base.a" "ggml/src/libggml-cpu.a" "ggml/src/ggml-metal/libggml-metal.a" "ggml/src/ggml-blas/libggml-blas.a")
+for lib_rel in "${LIB_NAMES[@]}"; do
+    mkdir -p "build-ios-sim-fat/$(dirname "${lib_rel}")"
+    lipo -create \
+        "build-ios-sim-arm64/${lib_rel}" \
+        "build-ios-sim-x86_64/${lib_rel}" \
+        -output "build-ios-sim-fat/${lib_rel}"
+done
+echo "  Fat simulator libraries created."
+
+# ----- Setup framework structures -----
+echo ""
+echo "Setting up framework structures..."
+
+FRAMEWORK_SIM="build-ios-sim-fat/framework/whisper.framework"
+FRAMEWORK_DEVICE="build-ios-device/framework/whisper.framework"
+FRAMEWORK_MACOS="build-macos/framework/whisper.framework"
+
+setup_framework_structure "${FRAMEWORK_SIM}" "${IOS_MIN_OS_VERSION}" "ios"
+setup_framework_structure "${FRAMEWORK_DEVICE}" "${IOS_MIN_OS_VERSION}" "ios"
+setup_framework_structure "${FRAMEWORK_MACOS}" "${MACOS_MIN_OS_VERSION}" "macos"
+
+# ----- Create dynamic libraries -----
+echo ""
+echo "Creating dynamic libraries..."
+
+# iOS Simulator (fat arm64+x86_64)
+echo "  iOS Simulator..."
+COMBINED_SIM="${BASE_DIR}/build-ios-sim-fat/temp/combined.a"
+mkdir -p "$(dirname "${COMBINED_SIM}")"
+libtool -static -o "${COMBINED_SIM}" \
+    build-ios-sim-fat/src/libwhisper.a \
+    build-ios-sim-fat/ggml/src/libggml.a \
+    build-ios-sim-fat/ggml/src/libggml-base.a \
+    build-ios-sim-fat/ggml/src/libggml-cpu.a \
+    build-ios-sim-fat/ggml/src/ggml-metal/libggml-metal.a \
+    build-ios-sim-fat/ggml/src/ggml-blas/libggml-blas.a \
+    2>/dev/null
+create_dynamic_lib "${COMBINED_SIM}" "${FRAMEWORK_SIM}/whisper" "${BASE_DIR}/build-ios-sim-fat/dSYMs" "ios" "true" "arm64" "x86_64"
+rm -rf build-ios-sim-fat/temp
+
+# iOS Device (arm64)
+echo "  iOS Device..."
+COMBINED_DEV="${BASE_DIR}/build-ios-device/temp/combined.a"
+mkdir -p "$(dirname "${COMBINED_DEV}")"
+libtool -static -o "${COMBINED_DEV}" \
+    build-ios-device/src/libwhisper.a \
+    build-ios-device/ggml/src/libggml.a \
+    build-ios-device/ggml/src/libggml-base.a \
+    build-ios-device/ggml/src/libggml-cpu.a \
+    build-ios-device/ggml/src/ggml-metal/libggml-metal.a \
+    build-ios-device/ggml/src/ggml-blas/libggml-blas.a \
+    2>/dev/null
+create_dynamic_lib "${COMBINED_DEV}" "${FRAMEWORK_DEVICE}/whisper" "${BASE_DIR}/build-ios-device/dSYMs" "ios" "false" "arm64"
+rm -rf build-ios-device/temp
+
+# macOS (arm64)
+echo "  macOS..."
+COMBINED_MAC="${BASE_DIR}/build-macos/temp/combined.a"
+mkdir -p "$(dirname "${COMBINED_MAC}")"
+libtool -static -o "${COMBINED_MAC}" \
+    build-macos/src/libwhisper.a \
+    build-macos/ggml/src/libggml.a \
+    build-macos/ggml/src/libggml-base.a \
+    build-macos/ggml/src/libggml-cpu.a \
+    build-macos/ggml/src/ggml-metal/libggml-metal.a \
+    build-macos/ggml/src/ggml-blas/libggml-blas.a \
+    2>/dev/null
+create_dynamic_lib "${COMBINED_MAC}" "${FRAMEWORK_MACOS}/Versions/A/whisper" "${BASE_DIR}/build-macos/dSYMs" "macos" "false" "arm64"
+rm -rf build-macos/temp
+
+# ----- Create xcframework -----
+echo ""
+echo "Creating xcframework..."
+xcodebuild -create-xcframework \
+    -framework "${BASE_DIR}/${FRAMEWORK_SIM}" \
+    -debug-symbols "${BASE_DIR}/build-ios-sim-fat/dSYMs/whisper.dSYM" \
+    -framework "${BASE_DIR}/${FRAMEWORK_DEVICE}" \
+    -debug-symbols "${BASE_DIR}/build-ios-device/dSYMs/whisper.dSYM" \
+    -framework "${BASE_DIR}/${FRAMEWORK_MACOS}" \
+    -debug-symbols "${BASE_DIR}/build-macos/dSYMs/whisper.dSYM" \
+    -output "${BASE_DIR}/build-apple/whisper.xcframework"
+
+# ----- Verify output -----
+if [ -d "build-apple/whisper.xcframework" ]; then
+    echo ""
+    echo "=========================================="
+    echo "SUCCESS: whisper.xcframework built"
+    echo "Location: ${WHISPER_DIR}/build-apple/whisper.xcframework"
+    echo ""
+    echo "Slices:"
+    ls -d build-apple/whisper.xcframework/*/
+    echo "=========================================="
+else
+    echo ""
+    echo "Error: xcframework was not created!"
+    exit 1
+fi

--- a/Scripts/build-xcframework.sh
+++ b/Scripts/build-xcframework.sh
@@ -444,7 +444,7 @@ libtool -static -o "${COMBINED_SIM}" \
     build-ios-sim-fat/ggml/src/libggml-cpu.a \
     build-ios-sim-fat/ggml/src/ggml-metal/libggml-metal.a \
     build-ios-sim-fat/ggml/src/ggml-blas/libggml-blas.a \
-    2>/dev/null
+    2> >(grep -v "table of contents" >&2)
 create_dynamic_lib "${COMBINED_SIM}" "${FRAMEWORK_SIM}/whisper" "${BASE_DIR}/build-ios-sim-fat/dSYMs" "ios" "true" "arm64" "x86_64"
 rm -rf build-ios-sim-fat/temp
 
@@ -459,7 +459,7 @@ libtool -static -o "${COMBINED_DEV}" \
     build-ios-device/ggml/src/libggml-cpu.a \
     build-ios-device/ggml/src/ggml-metal/libggml-metal.a \
     build-ios-device/ggml/src/ggml-blas/libggml-blas.a \
-    2>/dev/null
+    2> >(grep -v "table of contents" >&2)
 create_dynamic_lib "${COMBINED_DEV}" "${FRAMEWORK_DEVICE}/whisper" "${BASE_DIR}/build-ios-device/dSYMs" "ios" "false" "arm64"
 rm -rf build-ios-device/temp
 
@@ -474,7 +474,7 @@ libtool -static -o "${COMBINED_MAC}" \
     build-macos/ggml/src/libggml-cpu.a \
     build-macos/ggml/src/ggml-metal/libggml-metal.a \
     build-macos/ggml/src/ggml-blas/libggml-blas.a \
-    2>/dev/null
+    2> >(grep -v "table of contents" >&2)
 create_dynamic_lib "${COMBINED_MAC}" "${FRAMEWORK_MACOS}/Versions/A/whisper" "${BASE_DIR}/build-macos/dSYMs" "macos" "false" "arm64"
 rm -rf build-macos/temp
 

--- a/WhisperCore/Engines/TranscriptionEngine.swift
+++ b/WhisperCore/Engines/TranscriptionEngine.swift
@@ -1,13 +1,12 @@
 import Foundation
 import AVFoundation
 
-protocol TranscriptionEngine: AnyObject {
+public protocol TranscriptionEngine: AnyObject {
     var isModelLoaded: Bool { get }
     var engineName: String { get }
-    
+
     func initialize() async throws
-    func transcribeAudio(url: URL, settings: Settings) async throws -> String
+    func transcribeAudio(url: URL, settings: TranscriptionSettings) async throws -> String
     func cancelTranscription()
     func getSupportedLanguages() -> [String]
 }
-

--- a/WhisperCore/Engines/WhisperEngine.swift
+++ b/WhisperCore/Engines/WhisperEngine.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import CoreAudioTypes
+import whisper
 
 private class ProgressContext {
     var onProgress: ((Float) -> Void)?
@@ -21,14 +22,15 @@ private class ProgressContext {
     }
 }
 
-class WhisperEngine: TranscriptionEngine {
-    var engineName: String { "Whisper" }
-    
+public class WhisperEngine: TranscriptionEngine {
+    public var engineName: String { "Whisper" }
+
     private var context: MyWhisperContext?
     private let stateLock = NSLock()
     private var _isCancelled = false
     private var _abortFlag: UnsafeMutablePointer<Bool>?
     private var progressContext: ProgressContext?
+    private let textPostProcessor: TextPostProcessor
     
     private var isCancelled: Bool {
         get {
@@ -56,13 +58,17 @@ class WhisperEngine: TranscriptionEngine {
         }
     }
     
-    var onProgressUpdate: ((Float) -> Void)?
-    
-    var isModelLoaded: Bool {
+    public var onProgressUpdate: ((Float) -> Void)?
+
+    public var isModelLoaded: Bool {
         context != nil
     }
-    
-    func initialize() async throws {
+
+    public init(textPostProcessor: TextPostProcessor = NoOpTextPostProcessor()) {
+        self.textPostProcessor = textPostProcessor
+    }
+
+    public func initialize() async throws {
         let modelPath = AppPreferences.shared.selectedWhisperModelPath ?? AppPreferences.shared.selectedModelPath
         guard let modelPath = modelPath else {
             throw TranscriptionError.contextInitializationFailed
@@ -76,7 +82,7 @@ class WhisperEngine: TranscriptionEngine {
         }
     }
     
-    func transcribeAudio(url: URL, settings: Settings) async throws -> String {
+    public func transcribeAudio(url: URL, settings: TranscriptionSettings) async throws -> String {
         guard let context = context else {
             throw TranscriptionError.contextInitializationFailed
         }
@@ -201,20 +207,20 @@ class WhisperEngine: TranscriptionEngine {
         
         var processedText = cleanedText
         if settings.shouldApplyAsianAutocorrect && !cleanedText.isEmpty {
-            processedText = AutocorrectWrapper.format(cleanedText)
+            processedText = textPostProcessor.process(cleanedText, language: settings.selectedLanguage)
         }
         
         return processedText.isEmpty ? "No speech detected in the audio" : processedText
     }
     
-    func cancelTranscription() {
+    public func cancelTranscription() {
         isCancelled = true
         if let abortFlag = abortFlag {
             abortFlag.pointee = true
         }
     }
     
-    func getSupportedLanguages() -> [String] {
+    public func getSupportedLanguages() -> [String] {
         return LanguageUtil.availableLanguages
     }
     

--- a/WhisperCore/Models/Recording.swift
+++ b/WhisperCore/Models/Recording.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-enum RecordingStatus: String, Codable {
+public enum RecordingStatus: String, Codable {
     case pending
     case converting
     case transcribing
@@ -9,23 +9,23 @@ enum RecordingStatus: String, Codable {
     case failed
 }
 
-struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equatable {
-    let id: UUID
-    let timestamp: Date
-    let fileName: String
-    var transcription: String
-    let duration: TimeInterval
-    var status: RecordingStatus
-    var progress: Float
-    var sourceFileURL: String?
-    
-    var isRegeneration: Bool = false
-    
+public struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equatable {
+    public let id: UUID
+    public let timestamp: Date
+    public let fileName: String
+    public var transcription: String
+    public let duration: TimeInterval
+    public var status: RecordingStatus
+    public var progress: Float
+    public var sourceFileURL: String?
+
+    public var isRegeneration: Bool = false
+
     enum CodingKeys: String, CodingKey {
         case id, timestamp, fileName, transcription, duration, status, progress, sourceFileURL
     }
 
-    static func == (lhs: Recording, rhs: Recording) -> Bool {
+    public static func == (lhs: Recording, rhs: Recording) -> Bool {
         return lhs.id == rhs.id &&
                lhs.status == rhs.status &&
                lhs.progress == rhs.progress &&
@@ -33,7 +33,7 @@ struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equ
                lhs.isRegeneration == rhs.isRegeneration
     }
 
-    static var recordingsDirectory: URL {
+    public static var recordingsDirectory: URL {
         let applicationSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
         ).first!
@@ -41,38 +41,49 @@ struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equ
         return appDirectory.appendingPathComponent("recordings")
     }
 
-    var url: URL {
+    public var url: URL {
         Self.recordingsDirectory.appendingPathComponent(fileName)
     }
-    
-    var isPending: Bool {
+
+    public var isPending: Bool {
         status == .pending || status == .converting || status == .transcribing
     }
-    
-    var sourceFileName: String? {
+
+    public var sourceFileName: String? {
         guard let sourceFileURL = sourceFileURL else { return nil }
         return URL(fileURLWithPath: sourceFileURL).lastPathComponent
     }
 
-    static let databaseTableName = "recordings"
+    public static let databaseTableName = "recordings"
 
-    enum Columns {
-        static let id = Column(CodingKeys.id)
-        static let timestamp = Column(CodingKeys.timestamp)
-        static let fileName = Column(CodingKeys.fileName)
-        static let transcription = Column(CodingKeys.transcription)
-        static let duration = Column(CodingKeys.duration)
-        static let status = Column(CodingKeys.status)
-        static let progress = Column(CodingKeys.progress)
-        static let sourceFileURL = Column(CodingKeys.sourceFileURL)
+    public enum Columns {
+        public static let id = Column(CodingKeys.id)
+        public static let timestamp = Column(CodingKeys.timestamp)
+        public static let fileName = Column(CodingKeys.fileName)
+        public static let transcription = Column(CodingKeys.transcription)
+        public static let duration = Column(CodingKeys.duration)
+        public static let status = Column(CodingKeys.status)
+        public static let progress = Column(CodingKeys.progress)
+        public static let sourceFileURL = Column(CodingKeys.sourceFileURL)
+    }
+
+    public init(id: UUID, timestamp: Date, fileName: String, transcription: String, duration: TimeInterval, status: RecordingStatus, progress: Float, sourceFileURL: String?) {
+        self.id = id
+        self.timestamp = timestamp
+        self.fileName = fileName
+        self.transcription = transcription
+        self.duration = duration
+        self.status = status
+        self.progress = progress
+        self.sourceFileURL = sourceFileURL
     }
 }
 
 @MainActor
-class RecordingStore: ObservableObject {
-    static let shared = RecordingStore()
+public class RecordingStore: ObservableObject {
+    public static let shared = RecordingStore()
 
-    @Published private(set) var recordings: [Recording] = []
+    @Published public private(set) var recordings: [Recording] = []
     private let dbQueue: DatabaseQueue
 
     private init() {
@@ -96,7 +107,7 @@ class RecordingStore: ObservableObject {
 
     private nonisolated func setupDatabase() throws {
         var migrator = DatabaseMigrator()
-        
+
         migrator.registerMigration("v1") { db in
             try db.create(table: Recording.databaseTableName, ifNotExists: true) { t in
                 t.column("id", .text).primaryKey()
@@ -106,11 +117,11 @@ class RecordingStore: ObservableObject {
                 t.column("duration", .double).notNull()
             }
         }
-        
+
         migrator.registerMigration("v2_add_status") { db in
             let columns = try db.columns(in: Recording.databaseTableName)
             let columnNames = columns.map { $0.name }
-            
+
             if !columnNames.contains("status") {
                 try db.alter(table: Recording.databaseTableName) { t in
                     t.add(column: "status", .text).notNull().defaults(to: "completed")
@@ -127,10 +138,10 @@ class RecordingStore: ObservableObject {
                 }
             }
         }
-        
+
         try migrator.migrate(dbQueue)
     }
-    
+
     private nonisolated func fetchAllRecordings() async throws -> [Recording] {
         try await dbQueue.read { db in
             try Recording
@@ -138,8 +149,8 @@ class RecordingStore: ObservableObject {
                 .fetchAll(db)
         }
     }
-    
-    nonisolated func fetchRecordings(limit: Int, offset: Int) async throws -> [Recording] {
+
+    public nonisolated func fetchRecordings(limit: Int, offset: Int) async throws -> [Recording] {
         try await dbQueue.read { db in
             try Recording
                 .order(Recording.Columns.timestamp.desc)
@@ -148,7 +159,7 @@ class RecordingStore: ObservableObject {
         }
     }
 
-    func getPendingRecordings() -> [Recording] {
+    public func getPendingRecordings() -> [Recording] {
         do {
             return try dbQueue.read { db in
                 try Recording
@@ -162,7 +173,7 @@ class RecordingStore: ObservableObject {
         }
     }
 
-    func getNextPendingRecording() -> Recording? {
+    public func getNextPendingRecording() -> Recording? {
         do {
             return try dbQueue.read { db in
                 try Recording
@@ -177,9 +188,9 @@ class RecordingStore: ObservableObject {
         }
     }
 
-    static let recordingsDidUpdateNotification = Notification.Name("RecordingStore.recordingsDidUpdate")
+    public static let recordingsDidUpdateNotification = Notification.Name("RecordingStore.recordingsDidUpdate")
 
-    func addRecording(_ recording: Recording) {
+    public func addRecording(_ recording: Recording) {
         Task {
             do {
                 try await insertRecording(recording)
@@ -191,21 +202,21 @@ class RecordingStore: ObservableObject {
             }
         }
     }
-    
-    func addRecordingSync(_ recording: Recording) async throws {
+
+    public func addRecordingSync(_ recording: Recording) async throws {
         try await insertRecording(recording)
         await MainActor.run {
             NotificationCenter.default.post(name: Self.recordingsDidUpdateNotification, object: nil)
         }
     }
-    
+
     private nonisolated func insertRecording(_ recording: Recording) async throws {
         try await dbQueue.write { db in
             try recording.insert(db)
         }
     }
-    
-    func updateRecording(_ recording: Recording) {
+
+    public func updateRecording(_ recording: Recording) {
         Task {
             do {
                 try await updateRecordingInDB(recording)
@@ -217,23 +228,23 @@ class RecordingStore: ObservableObject {
             }
         }
     }
-    
-    func updateRecordingSync(_ recording: Recording) async throws {
+
+    public func updateRecordingSync(_ recording: Recording) async throws {
         try await updateRecordingInDB(recording)
         await MainActor.run {
             NotificationCenter.default.post(name: Self.recordingsDidUpdateNotification, object: nil)
         }
     }
-    
-    func updateRecordingProgressOnly(_ id: UUID, transcription: String, progress: Float, status: RecordingStatus) {
+
+    public func updateRecordingProgressOnly(_ id: UUID, transcription: String, progress: Float, status: RecordingStatus) {
         Task {
             await updateRecordingProgressOnlySync(id, transcription: transcription, progress: progress, status: status)
         }
     }
-    
-    static let recordingProgressDidUpdateNotification = Notification.Name("RecordingStore.recordingProgressDidUpdate")
-    
-    func updateRecordingProgressOnlySync(_ id: UUID, transcription: String, progress: Float, status: RecordingStatus, isRegeneration: Bool? = nil) async {
+
+    public static let recordingProgressDidUpdateNotification = Notification.Name("RecordingStore.recordingProgressDidUpdate")
+
+    public func updateRecordingProgressOnlySync(_ id: UUID, transcription: String, progress: Float, status: RecordingStatus, isRegeneration: Bool? = nil) async {
         do {
             _ = try await dbQueue.write { db -> Int in
                 try Recording
@@ -254,7 +265,7 @@ class RecordingStore: ObservableObject {
                 }
                 recordings[index] = updated
             }
-            
+
             var userInfo: [String: Any] = [
                 "id": id,
                 "transcription": transcription,
@@ -264,7 +275,7 @@ class RecordingStore: ObservableObject {
             if let isRegeneration = isRegeneration {
                 userInfo["isRegeneration"] = isRegeneration
             }
-            
+
             await MainActor.run {
                 NotificationCenter.default.post(name: Self.recordingProgressDidUpdateNotification, object: nil, userInfo: userInfo)
             }
@@ -273,7 +284,7 @@ class RecordingStore: ObservableObject {
         }
     }
 
-    nonisolated func updateSourceFileURL(_ id: UUID, sourceURL: String) async throws {
+    public nonisolated func updateSourceFileURL(_ id: UUID, sourceURL: String) async throws {
         try await dbQueue.write { db in
             try Recording
                 .filter(Recording.Columns.id == id)
@@ -283,7 +294,7 @@ class RecordingStore: ObservableObject {
         }
     }
 
-    func updateRecordingStatusOnly(_ id: UUID, progress: Float, status: RecordingStatus, isRegeneration: Bool? = nil) async {
+    public func updateRecordingStatusOnly(_ id: UUID, progress: Float, status: RecordingStatus, isRegeneration: Bool? = nil) async {
         do {
             _ = try await dbQueue.write { db -> Int in
                 try Recording
@@ -302,7 +313,7 @@ class RecordingStore: ObservableObject {
                 }
                 recordings[index] = updated
             }
-            
+
             var userInfo: [String: Any] = [
                 "id": id,
                 "progress": progress,
@@ -311,7 +322,7 @@ class RecordingStore: ObservableObject {
             if let isRegeneration = isRegeneration {
                 userInfo["isRegeneration"] = isRegeneration
             }
-            
+
             await MainActor.run {
                 NotificationCenter.default.post(name: Self.recordingProgressDidUpdateNotification, object: nil, userInfo: userInfo)
             }
@@ -326,11 +337,11 @@ class RecordingStore: ObservableObject {
         }
     }
 
-    func deleteRecording(_ recording: Recording) {
+    public func deleteRecording(_ recording: Recording) {
         if recording.isPending {
             TranscriptionQueue.shared.cancelRecording(recording.id)
         }
-        
+
         Task {
             do {
                 try await deleteRecordingFromDB(recording)
@@ -343,14 +354,14 @@ class RecordingStore: ObservableObject {
             }
         }
     }
-    
+
     private nonisolated func deleteRecordingFromDB(_ recording: Recording) async throws {
         try await dbQueue.write { db in
             _ = try recording.delete(db)
         }
     }
 
-    func deleteAllRecordings() {
+    public func deleteAllRecordings() {
         Task {
             do {
                 let allRecordings = try await fetchAllRecordings()
@@ -366,14 +377,14 @@ class RecordingStore: ObservableObject {
             }
         }
     }
-    
+
     private nonisolated func deleteAllRecordingsFromDB() async throws {
         try await dbQueue.write { db in
             _ = try Recording.deleteAll(db)
         }
     }
 
-    func searchRecordings(query: String) -> [Recording] {
+    public func searchRecordings(query: String) -> [Recording] {
         do {
             return try dbQueue.read { db in
                 try Recording
@@ -387,8 +398,8 @@ class RecordingStore: ObservableObject {
             return []
         }
     }
-    
-    nonisolated func searchRecordingsAsync(query: String, limit: Int = 100, offset: Int = 0) async -> [Recording] {
+
+    public nonisolated func searchRecordingsAsync(query: String, limit: Int = 100, offset: Int = 0) async -> [Recording] {
         do {
             return try await dbQueue.read { db in
                 try Recording

--- a/WhisperCore/Models/RecordingState.swift
+++ b/WhisperCore/Models/RecordingState.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Represents the current state of the recording/transcription pipeline.
+public enum RecordingState: Equatable {
+    case idle
+    case connecting
+    case recording
+    case decoding
+    case busy
+}

--- a/WhisperCore/Models/TranscriptionSettings.swift
+++ b/WhisperCore/Models/TranscriptionSettings.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Settings for a transcription operation.
+/// Populated from AppPreferences at transcription time.
+public struct TranscriptionSettings {
+    public static let asianLanguages: Set<String> = ["zh", "ja", "ko"]
+
+    public var selectedLanguage: String
+    public var translateToEnglish: Bool
+    public var suppressBlankAudio: Bool
+    public var showTimestamps: Bool
+    public var temperature: Double
+    public var noSpeechThreshold: Double
+    public var initialPrompt: String
+    public var useBeamSearch: Bool
+    public var beamSize: Int
+    public var useAsianAutocorrect: Bool
+
+    public var isAsianLanguage: Bool {
+        Self.asianLanguages.contains(selectedLanguage)
+    }
+
+    public var shouldApplyAsianAutocorrect: Bool {
+        isAsianLanguage && useAsianAutocorrect
+    }
+
+    public init() {
+        let prefs = AppPreferences.shared
+        self.selectedLanguage = prefs.whisperLanguage
+        self.translateToEnglish = prefs.translateToEnglish
+        self.suppressBlankAudio = prefs.suppressBlankAudio
+        self.showTimestamps = prefs.showTimestamps
+        self.temperature = prefs.temperature
+        self.noSpeechThreshold = prefs.noSpeechThreshold
+        self.initialPrompt = prefs.initialPrompt
+        self.useBeamSearch = prefs.useBeamSearch
+        self.beamSize = prefs.beamSize
+        self.useAsianAutocorrect = prefs.useAsianAutocorrect
+    }
+}

--- a/WhisperCore/Protocols/AudioRecording.swift
+++ b/WhisperCore/Protocols/AudioRecording.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Combine
+
+/// Platform-agnostic protocol for audio recording.
+/// macOS: Implemented by AudioRecorder (AppKit/CoreAudio)
+/// iOS: Implemented by iOSAudioRecorder (AVAudioSession) in future cycle
+public protocol AudioRecording: ObservableObject {
+    var isRecording: Bool { get }
+    var isConnecting: Bool { get }
+    var canRecord: Bool { get }
+    var currentTime: TimeInterval { get }
+
+    func startRecording()
+    func stopRecording() -> URL?
+    func cancelRecording()
+}

--- a/WhisperCore/Protocols/ClipboardService.swift
+++ b/WhisperCore/Protocols/ClipboardService.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Platform-agnostic protocol for clipboard operations.
+/// macOS: Implemented by ClipboardUtil (NSPasteboard)
+/// iOS: Implemented by iOSClipboardService (UIPasteboard) in future cycle
+public protocol ClipboardService {
+    func copyToClipboard(_ text: String)
+    func getClipboardText() -> String?
+}

--- a/WhisperCore/Protocols/TextPostProcessor.swift
+++ b/WhisperCore/Protocols/TextPostProcessor.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Protocol for post-processing transcribed text.
+/// Replaces the hard dependency on AutocorrectWrapper in WhisperEngine.
+/// macOS: Implemented with AutocorrectWrapper (Rust CJK autocorrect)
+/// iOS: No-op implementation initially (autocorrect deferred)
+public protocol TextPostProcessor {
+    func process(_ text: String, language: String) -> String
+}
+
+/// Default no-op implementation
+public struct NoOpTextPostProcessor: TextPostProcessor {
+    public init() {}
+    public func process(_ text: String, language: String) -> String { text }
+}

--- a/WhisperCore/TranscriptionQueue.swift
+++ b/WhisperCore/TranscriptionQueue.swift
@@ -3,11 +3,11 @@ import AVFoundation
 import Combine
 
 @MainActor
-class TranscriptionQueue: ObservableObject {
-    static let shared = TranscriptionQueue()
+public class TranscriptionQueue: ObservableObject {
+    public static let shared = TranscriptionQueue()
 
-    @Published private(set) var isProcessing = false
-    @Published private(set) var currentRecordingId: UUID?
+    @Published public private(set) var isProcessing = false
+    @Published public private(set) var currentRecordingId: UUID?
 
     private let transcriptionService: TranscriptionService
     private let recordingStore: RecordingStore
@@ -21,7 +21,7 @@ class TranscriptionQueue: ObservableObject {
         self.recordingStore = RecordingStore.shared
         setupProgressObserver()
     }
-    
+
     private func setupProgressObserver() {
         progressCancellable = transcriptionService.$progress
             .receive(on: DispatchQueue.main)
@@ -30,7 +30,7 @@ class TranscriptionQueue: ObservableObject {
                       let recordingId = self.currentRecordingId,
                       newProgress > 0,
                       newProgress < 1.0 else { return }
-                
+
                 Task {
                     await self.recordingStore.updateRecordingStatusOnly(
                         recordingId,
@@ -41,7 +41,7 @@ class TranscriptionQueue: ObservableObject {
             }
     }
 
-    func cancelRecording(_ recordingId: UUID) {
+    public func cancelRecording(_ recordingId: UUID) {
         cancelledRecordingIds.insert(recordingId)
 
         if currentRecordingId == recordingId {
@@ -58,7 +58,7 @@ class TranscriptionQueue: ObservableObject {
         cancelledRecordingIds.remove(recordingId)
     }
 
-    func startProcessingQueue() {
+    public func startProcessingQueue() {
         guard !isProcessing else { return }
 
         isProcessing = true
@@ -90,13 +90,13 @@ class TranscriptionQueue: ObservableObject {
             }
             return toDelete
         }.value
-        
+
         for recording in recordingsToDelete {
             recordingStore.deleteRecording(recording)
         }
     }
 
-    func addFileToQueue(url: URL) async {
+    public func addFileToQueue(url: URL) async {
         do {
             let durationInSeconds = await (try? Task.detached(priority: .userInitiated) {
                 let asset = AVAsset(url: url)
@@ -127,7 +127,7 @@ class TranscriptionQueue: ObservableObject {
         }
     }
 
-    func requeueRecording(_ recording: Recording) async {
+    public func requeueRecording(_ recording: Recording) async {
         let sourceURL: URL? = await Task.detached(priority: .userInitiated) {
             if let existingSource = recording.sourceFileURL,
                !existingSource.isEmpty,
@@ -138,7 +138,7 @@ class TranscriptionQueue: ObservableObject {
             }
             return nil
         }.value
-        
+
         guard let sourceURL = sourceURL else {
             await recordingStore.updateRecordingProgressOnlySync(
                 recording.id,
@@ -195,7 +195,7 @@ class TranscriptionQueue: ObservableObject {
         let sourceExists = await Task.detached(priority: .userInitiated) {
             FileManager.default.fileExists(atPath: sourceURL.path)
         }.value
-        
+
         guard sourceExists else {
             await recordingStore.updateRecordingProgressOnlySync(
                 recording.id,
@@ -206,8 +206,8 @@ class TranscriptionQueue: ObservableObject {
             return
         }
 
-        let isRegeneration = !recording.transcription.isEmpty && 
-            recording.transcription != "In queue..." && 
+        let isRegeneration = !recording.transcription.isEmpty &&
+            recording.transcription != "In queue..." &&
             recording.transcription != "Starting transcription..."
 
         if isRegeneration {
@@ -235,7 +235,7 @@ class TranscriptionQueue: ObservableObject {
                     return
                 }
 
-                let settings = Settings()
+                let settings = TranscriptionSettings()
                 let text = try await transcriptionService.transcribeAudio(url: sourceURL, settings: settings)
 
                 if isRecordingCancelled(recording.id) || Task.isCancelled {

--- a/WhisperCore/TranscriptionService.swift
+++ b/WhisperCore/TranscriptionService.swift
@@ -16,6 +16,10 @@ public class TranscriptionService: ObservableObject {
     /// Platform provides a text post-processor (e.g., autocorrect on macOS)
     public var textPostProcessor: TextPostProcessor = NoOpTextPostProcessor()
 
+    /// Platform provides an alternative engine factory (e.g., FluidAudioEngine on macOS).
+    /// Returns nil if the platform engine is unavailable.
+    public var alternateEngineFactory: (() async -> TranscriptionEngine?)?
+
     private var currentEngine: TranscriptionEngine?
     private var totalDuration: Float = 0.0
     private var transcriptionTask: Task<String, Error>? = nil
@@ -47,13 +51,8 @@ public class TranscriptionService: ObservableObject {
             let engine: TranscriptionEngine?
             let postProcessor = await self.textPostProcessor
 
-            if selectedEngine == "fluidaudio" {
-                #if canImport(FluidAudio)
-                engine = await FluidAudioEngine()
-                #else
-                // FluidAudio not available on this platform — fall back to Whisper
-                engine = await WhisperEngine(textPostProcessor: postProcessor)
-                #endif
+            if selectedEngine == "fluidaudio", let factory = await self.alternateEngineFactory {
+                engine = await factory()
             } else {
                 engine = await WhisperEngine(textPostProcessor: postProcessor)
             }

--- a/WhisperCore/TranscriptionService.swift
+++ b/WhisperCore/TranscriptionService.swift
@@ -2,56 +2,65 @@ import AVFoundation
 import Foundation
 
 @MainActor
-class TranscriptionService: ObservableObject {
-    static let shared = TranscriptionService()
-    
-    @Published private(set) var isTranscribing = false
-    @Published private(set) var transcribedText = ""
-    @Published private(set) var currentSegment = ""
-    @Published private(set) var isLoading = false
-    @Published private(set) var progress: Float = 0.0
-    @Published private(set) var isConverting = false
-    @Published private(set) var conversionProgress: Float = 0.0
-    
+public class TranscriptionService: ObservableObject {
+    public static let shared = TranscriptionService()
+
+    @Published public private(set) var isTranscribing = false
+    @Published public private(set) var transcribedText = ""
+    @Published public private(set) var currentSegment = ""
+    @Published public private(set) var isLoading = false
+    @Published public private(set) var progress: Float = 0.0
+    @Published public private(set) var isConverting = false
+    @Published public private(set) var conversionProgress: Float = 0.0
+
+    /// Platform provides a text post-processor (e.g., autocorrect on macOS)
+    public var textPostProcessor: TextPostProcessor = NoOpTextPostProcessor()
+
     private var currentEngine: TranscriptionEngine?
     private var totalDuration: Float = 0.0
     private var transcriptionTask: Task<String, Error>? = nil
     private var isCancelled = false
-    
-    init() {
+
+    public init() {
         loadEngine()
     }
-    
-    func cancelTranscription() {
+
+    public func cancelTranscription() {
         isCancelled = true
         currentEngine?.cancelTranscription()
         transcriptionTask?.cancel()
         transcriptionTask = nil
-        
+
         isTranscribing = false
         currentSegment = ""
         progress = 0.0
         isCancelled = false
     }
-    
+
     private func loadEngine() {
         let selectedEngine = AppPreferences.shared.selectedEngine
         print("Loading engine: \(selectedEngine)")
-        
+
         isLoading = true
-        
+
         Task.detached(priority: .userInitiated) {
             let engine: TranscriptionEngine?
-            
+            let postProcessor = await self.textPostProcessor
+
             if selectedEngine == "fluidaudio" {
+                #if canImport(FluidAudio)
                 engine = await FluidAudioEngine()
+                #else
+                // FluidAudio not available on this platform — fall back to Whisper
+                engine = await WhisperEngine(textPostProcessor: postProcessor)
+                #endif
             } else {
-                engine = await WhisperEngine()
+                engine = await WhisperEngine(textPostProcessor: postProcessor)
             }
-            
+
             do {
                 try await engine?.initialize()
-                
+
                 await MainActor.run {
                     self.currentEngine = engine
                     self.isLoading = false
@@ -65,19 +74,19 @@ class TranscriptionService: ObservableObject {
             }
         }
     }
-    
-    func reloadEngine() {
+
+    public func reloadEngine() {
         loadEngine()
     }
-    
-    func reloadModel(with path: String) {
+
+    public func reloadModel(with path: String) {
         if AppPreferences.shared.selectedEngine == "whisper" {
             AppPreferences.shared.selectedWhisperModelPath = path
             reloadEngine()
         }
     }
-    
-    func transcribeAudio(url: URL, settings: Settings) async throws -> String {
+
+    public func transcribeAudio(url: URL, settings: TranscriptionSettings) async throws -> String {
         await MainActor.run {
             self.progress = 0.0
             self.conversionProgress = 0.0
@@ -87,7 +96,7 @@ class TranscriptionService: ObservableObject {
             self.currentSegment = ""
             self.isCancelled = false
         }
-        
+
         defer {
             Task { @MainActor in
                 self.isTranscribing = false
@@ -99,21 +108,21 @@ class TranscriptionService: ObservableObject {
                 self.transcriptionTask = nil
             }
         }
-        
+
         let durationInSeconds: Float = await (try? Task.detached(priority: .userInitiated) {
             let asset = AVAsset(url: url)
             let duration = try await asset.load(.duration)
             return Float(CMTimeGetSeconds(duration))
         }.value) ?? 0.0
-        
+
         await MainActor.run {
             self.totalDuration = durationInSeconds
         }
-        
+
         guard let engine = currentEngine else {
             throw TranscriptionError.contextInitializationFailed
         }
-        
+
         // Setup progress callback for engines
         if let whisperEngine = engine as? WhisperEngine {
             whisperEngine.onProgressUpdate = { [weak self] newProgress in
@@ -122,53 +131,46 @@ class TranscriptionService: ObservableObject {
                     self.progress = newProgress
                 }
             }
-        } else if let fluidEngine = engine as? FluidAudioEngine {
-            fluidEngine.onProgressUpdate = { [weak self] newProgress in
-                Task { @MainActor in
-                    guard let self = self, !self.isCancelled else { return }
-                    self.progress = newProgress
-                }
-            }
         }
-        
+
         let task = Task.detached(priority: .userInitiated) { [weak self] in
             try Task.checkCancellation()
-            
+
             let cancelled = await MainActor.run {
                 guard let self = self else { return true }
                 return self.isCancelled
             }
-            
+
             guard !cancelled else {
                 throw CancellationError()
             }
-            
+
             let result = try await engine.transcribeAudio(url: url, settings: settings)
-            
+
             try Task.checkCancellation()
-            
+
             let finalCancelled = await MainActor.run {
                 guard let self = self else { return true }
                 return self.isCancelled
             }
-            
+
             await MainActor.run {
                 guard let self = self, !self.isCancelled else { return }
                 self.transcribedText = result
                 self.progress = 1.0
             }
-            
+
             guard !finalCancelled else {
                 throw CancellationError()
             }
-            
+
             return result
         }
-        
+
         await MainActor.run {
             self.transcriptionTask = task
         }
-        
+
         do {
             return try await task.value
         } catch is CancellationError {
@@ -180,7 +182,7 @@ class TranscriptionService: ObservableObject {
     }
 }
 
-enum TranscriptionError: Error {
+public enum TranscriptionError: Error {
     case contextInitializationFailed
     case audioConversionFailed
     case processingFailed

--- a/WhisperCore/Utils/AppPreferences.swift
+++ b/WhisperCore/Utils/AppPreferences.swift
@@ -1,45 +1,45 @@
 import Foundation
 
 @propertyWrapper
-struct UserDefault<T> {
+public struct UserDefault<T> {
     let key: String
     let defaultValue: T
-    
-    var wrappedValue: T {
+
+    public var wrappedValue: T {
         get { UserDefaults.standard.object(forKey: key) as? T ?? defaultValue }
         set { UserDefaults.standard.set(newValue, forKey: key) }
     }
 }
 
 @propertyWrapper
-struct OptionalUserDefault<T> {
+public struct OptionalUserDefault<T> {
     let key: String
-    
-    var wrappedValue: T? {
+
+    public var wrappedValue: T? {
         get { UserDefaults.standard.object(forKey: key) as? T }
         set { UserDefaults.standard.set(newValue, forKey: key) }
     }
 }
 
-final class AppPreferences {
-    static let shared = AppPreferences()
+public final class AppPreferences {
+    public static let shared = AppPreferences()
     private init() {
         migrateOldPreferences()
     }
-    
+
     private func migrateOldPreferences() {
         if let oldPath = UserDefaults.standard.string(forKey: "selectedModelPath"),
            UserDefaults.standard.string(forKey: "selectedWhisperModelPath") == nil {
             UserDefaults.standard.set(oldPath, forKey: "selectedWhisperModelPath")
         }
     }
-    
+
     // Engine settings
     @UserDefault(key: "selectedEngine", defaultValue: "whisper")
-    var selectedEngine: String
-    
+    public var selectedEngine: String
+
     // Model settings
-    var selectedModelPath: String? {
+    public var selectedModelPath: String? {
         get {
             if selectedEngine == "whisper" {
                 return selectedWhisperModelPath
@@ -52,62 +52,62 @@ final class AppPreferences {
             }
         }
     }
-    
+
     @OptionalUserDefault(key: "selectedWhisperModelPath")
-    var selectedWhisperModelPath: String?
-    
+    public var selectedWhisperModelPath: String?
+
     @UserDefault(key: "fluidAudioModelVersion", defaultValue: "v3")
-    var fluidAudioModelVersion: String
-    
+    public var fluidAudioModelVersion: String
+
     @UserDefault(key: "whisperLanguage", defaultValue: "en")
-    var whisperLanguage: String
-    
+    public var whisperLanguage: String
+
     // Transcription settings
     @UserDefault(key: "translateToEnglish", defaultValue: false)
-    var translateToEnglish: Bool
-    
+    public var translateToEnglish: Bool
+
     @UserDefault(key: "suppressBlankAudio", defaultValue: true)
-    var suppressBlankAudio: Bool
-    
+    public var suppressBlankAudio: Bool
+
     @UserDefault(key: "showTimestamps", defaultValue: false)
-    var showTimestamps: Bool
-    
+    public var showTimestamps: Bool
+
     @UserDefault(key: "temperature", defaultValue: 0.0)
-    var temperature: Double
-    
+    public var temperature: Double
+
     @UserDefault(key: "noSpeechThreshold", defaultValue: 0.6)
-    var noSpeechThreshold: Double
-    
+    public var noSpeechThreshold: Double
+
     @UserDefault(key: "initialPrompt", defaultValue: "")
-    var initialPrompt: String
-    
+    public var initialPrompt: String
+
     @UserDefault(key: "useBeamSearch", defaultValue: false)
-    var useBeamSearch: Bool
-    
+    public var useBeamSearch: Bool
+
     @UserDefault(key: "beamSize", defaultValue: 5)
-    var beamSize: Int
-    
+    public var beamSize: Int
+
     @UserDefault(key: "debugMode", defaultValue: false)
-    var debugMode: Bool
-    
+    public var debugMode: Bool
+
     @UserDefault(key: "playSoundOnRecordStart", defaultValue: false)
-    var playSoundOnRecordStart: Bool
-    
+    public var playSoundOnRecordStart: Bool
+
     @UserDefault(key: "hasCompletedOnboarding", defaultValue: false)
-    var hasCompletedOnboarding: Bool
-    
+    public var hasCompletedOnboarding: Bool
+
     @UserDefault(key: "useAsianAutocorrect", defaultValue: true)
-    var useAsianAutocorrect: Bool
-    
+    public var useAsianAutocorrect: Bool
+
     @OptionalUserDefault(key: "selectedMicrophoneData")
-    var selectedMicrophoneData: Data?
-    
+    public var selectedMicrophoneData: Data?
+
     @UserDefault(key: "modifierOnlyHotkey", defaultValue: "none")
-    var modifierOnlyHotkey: String
-    
+    public var modifierOnlyHotkey: String
+
     @UserDefault(key: "holdToRecord", defaultValue: true)
-    var holdToRecord: Bool
-    
+    public var holdToRecord: Bool
+
     @UserDefault(key: "addSpaceAfterSentence", defaultValue: true)
-    var addSpaceAfterSentence: Bool
+    public var addSpaceAfterSentence: Bool
 }

--- a/WhisperCore/Utils/LanguageUtil.swift
+++ b/WhisperCore/Utils/LanguageUtil.swift
@@ -1,12 +1,13 @@
 import Foundation
-class LanguageUtil {
 
-    static let availableLanguages = [
+public class LanguageUtil {
+
+    public static let availableLanguages = [
         "auto", "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
         "sv", "it", "id", "hi", "fi",
     ]
 
-    static let languageNames = [
+    public static let languageNames = [
         "auto": "Auto-detect",
         "en": "English",
         "zh": "Chinese",
@@ -29,7 +30,7 @@ class LanguageUtil {
         "fi": "Finnish",
     ]
 
-    static func getSystemLanguage() -> String {
+    public static func getSystemLanguage() -> String {
         if let preferredLanguage = Locale.preferredLanguages.first {
             let preferredLanguage = preferredLanguage.prefix(2).lowercased()
             return availableLanguages.contains(preferredLanguage) ? preferredLanguage : "en"

--- a/WhisperCore/Utils/NotificationName+App.swift
+++ b/WhisperCore/Utils/NotificationName+App.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Notification.Name {
+public extension Notification.Name {
     static let appPreferencesLanguageChanged = Notification.Name("AppPreferencesLanguageChanged")
     static let hotkeySettingsChanged = Notification.Name("HotkeySettingsChanged")
     static let indicatorWindowDidHide = Notification.Name("IndicatorWindowDidHide")

--- a/WhisperCore/Utils/TextUtil.swift
+++ b/WhisperCore/Utils/TextUtil.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-enum TextUtil {
+public enum TextUtil {
 
     /// Counts words in a string, handling leading/trailing whitespace,
     /// multiple consecutive spaces, and newlines.
-    static func wordCount(_ text: String) -> Int {
+    public static func wordCount(_ text: String) -> Int {
         text.split(whereSeparator: \.isWhitespace).count
     }
 
     /// Formats a TimeInterval as a localized, human-readable duration string.
     /// Sub-second precision is truncated. Leading zero units are dropped.
-    /// e.g. 65 → "1m 5s", 30 → "30s", 3661 → "1h 1m 1s"
-    static func formatDuration(_ duration: TimeInterval) -> String {
+    /// e.g. 65 -> "1m 5s", 30 -> "30s", 3661 -> "1h 1m 1s"
+    public static func formatDuration(_ duration: TimeInterval) -> String {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated

--- a/WhisperCore/Whis/Whis.swift
+++ b/WhisperCore/Whis/Whis.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import whisper
 
 // MARK: - C Type Wrappers
 

--- a/WhisperCore/Whis/WhisperAhead.swift
+++ b/WhisperCore/Whis/WhisperAhead.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperAhead {
     public let nTextLayer: Int32

--- a/WhisperCore/Whis/WhisperAheads.swift
+++ b/WhisperCore/Whis/WhisperAheads.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperAheads {
     public let heads: [WhisperAhead]

--- a/WhisperCore/Whis/WhisperAlignmentHeadsPreset.swift
+++ b/WhisperCore/Whis/WhisperAlignmentHeadsPreset.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public enum WhisperAlignmentHeadsPreset: Int32 {
     case none

--- a/WhisperCore/Whis/WhisperContextParams.swift
+++ b/WhisperCore/Whis/WhisperContextParams.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperContextParams {
     public var useGPU: Bool = true

--- a/WhisperCore/Whis/WhisperFullParams.swift
+++ b/WhisperCore/Whis/WhisperFullParams.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperFullParams {
     public var strategy: WhisperSamplingStrategy = .greedy

--- a/WhisperCore/Whis/WhisperGrammarElement.swift
+++ b/WhisperCore/Whis/WhisperGrammarElement.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperGrammarElement {
     public let type: WhisperGrammarElementType

--- a/WhisperCore/Whis/WhisperGrammarElementType.swift
+++ b/WhisperCore/Whis/WhisperGrammarElementType.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public enum WhisperGrammarElementType: Int32 {
     case end = 0

--- a/WhisperCore/Whis/WhisperModelLoader.swift
+++ b/WhisperCore/Whis/WhisperModelLoader.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperModelLoader {
     public var context: UnsafeMutableRawPointer?

--- a/WhisperCore/Whis/WhisperSamplingStrategy.swift
+++ b/WhisperCore/Whis/WhisperSamplingStrategy.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public enum WhisperSamplingStrategy: Int32 {
     case greedy = 0

--- a/WhisperCore/Whis/WhisperTimings.swift
+++ b/WhisperCore/Whis/WhisperTimings.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperTimings {
     public let sampleMs: Float

--- a/WhisperCore/Whis/WhisperTokenData.swift
+++ b/WhisperCore/Whis/WhisperTokenData.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import whisper
 
 public struct WhisperTokenData {
     public let id: WhisperToken

--- a/WhisperCore/WhisperModelManager.swift
+++ b/WhisperCore/WhisperModelManager.swift
@@ -40,14 +40,14 @@ class WhisperDownloadDelegate: NSObject, URLSessionTaskDelegate, URLSessionDownl
     }
 }
 
-class WhisperModelManager {
-    static let shared = WhisperModelManager()
+public class WhisperModelManager {
+    public static let shared = WhisperModelManager()
     
     private let modelsDirectoryName = "whisper-models"
     private var activeDownloadTasks: [String: URLSessionDownloadTask] = [:]
     private let downloadTasksLock = NSLock()
     
-    var modelsDirectory: URL {
+    public var modelsDirectory: URL {
         let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let modelsDirectory = applicationSupport.appendingPathComponent(Bundle.main.bundleIdentifier!).appendingPathComponent(modelsDirectoryName)
         return modelsDirectory
@@ -95,7 +95,7 @@ class WhisperModelManager {
         }
     }
     
-    func getAvailableModels() -> [URL] {
+    public func getAvailableModels() -> [URL] {
         do {
             return try FileManager.default.contentsOfDirectory(at: modelsDirectory, includingPropertiesForKeys: nil)
                 .filter { $0.pathExtension == "bin" }
@@ -107,7 +107,7 @@ class WhisperModelManager {
     }
     
     // Download model with progress callback using delegate
-    func downloadModel(url: URL, name: String, progressCallback: @escaping (Double) -> Void) async throws {
+    public func downloadModel(url: URL, name: String, progressCallback: @escaping (Double) -> Void) async throws {
         let destinationURL = modelsDirectory.appendingPathComponent(name)
         
         // Check if model already exists
@@ -188,7 +188,7 @@ class WhisperModelManager {
     }
     
     // Cancel download task
-    func cancelDownload(name: String) {
+    public func cancelDownload(name: String) {
         downloadTasksLock.lock()
         defer { downloadTasksLock.unlock() }
         
@@ -200,7 +200,7 @@ class WhisperModelManager {
     }
     
     // Check if specific model is downloaded
-    func isModelDownloaded(name: String) -> Bool {
+    public func isModelDownloaded(name: String) -> Bool {
         let modelPath = modelsDirectory.appendingPathComponent(name).path
         return FileManager.default.fileExists(atPath: modelPath)
     }

--- a/run.sh
+++ b/run.sh
@@ -1,58 +1,82 @@
 #!/bin/zsh
 
 JUST_BUILD=false
-if [[ "$1" == "build" ]]; then
-    JUST_BUILD=true
-fi
+BUILD_IOS=false
+BUILD_XCFRAMEWORK_ONLY=false
 
-# Configure libwhisper
-echo "Configuring libwhisper..."
-cmake -G Xcode -B libwhisper/build -S libwhisper
+case "$1" in
+    build)
+        JUST_BUILD=true
+        ;;
+    build-ios)
+        JUST_BUILD=true
+        BUILD_IOS=true
+        ;;
+    build-xcframework)
+        BUILD_XCFRAMEWORK_ONLY=true
+        ;;
+esac
+
+# Phase 1: Build whisper.xcframework (replaces old cmake libwhisper.a path)
+echo "Building whisper.xcframework..."
+./Scripts/build-xcframework.sh
 if [[ $? -ne 0 ]]; then
-    echo "CMake configuration failed!"
+    echo "xcframework build failed!"
     exit 1
 fi
-
-echo "Building autocorrect-swift..."
-mkdir -p build
-cargo build -p autocorrect-swift --release --target aarch64-apple-darwin --manifest-path=asian-autocorrect/Cargo.toml
-cp ./asian-autocorrect/target/aarch64-apple-darwin/release/libautocorrect_swift.dylib ./build/libautocorrect_swift.dylib
-install_name_tool -id "@rpath/libautocorrect_swift.dylib" ./build/libautocorrect_swift.dylib
-codesign --force --sign - ./build/libautocorrect_swift.dylib
-if [[ $? -ne 0 ]]; then
-    echo "Cargo build failed!"
-    exit 1
+if [[ "$BUILD_XCFRAMEWORK_ONLY" == true ]]; then
+    echo "xcframework build complete."
+    exit 0
 fi
 
-echo "Copying libomp.dylib..."
-cp /opt/homebrew/opt/libomp/lib/libomp.dylib ./build/libomp.dylib
-install_name_tool -id "@rpath/libomp.dylib" ./build/libomp.dylib
-codesign --force --sign - ./build/libomp.dylib
-
-# Build the app
-echo "Building OpenSuperWhisper..."
-BUILD_OUTPUT=$(xcodebuild -scheme OpenSuperWhisper -configuration Debug -jobs 8 -derivedDataPath build -quiet -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation -skipMacroValidation -UseModernBuildSystem=YES -clonedSourcePackagesDirPath SourcePackages -skipUnavailableActions CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO OTHER_CODE_SIGN_FLAGS="--entitlements OpenSuperWhisper/OpenSuperWhisper.entitlements" build 2>&1)
-
-# sudo gem install xcpretty
-if command -v xcpretty &> /dev/null
-then
-    echo "$BUILD_OUTPUT" | xcpretty --simple --color
-else
-    echo "$BUILD_OUTPUT"
-fi
-
-# Check if build output contains BUILD FAILED or if the command failed
-if [[ $? -eq 0 ]] && [[ ! "$BUILD_OUTPUT" =~ "BUILD FAILED" ]]; then
-    echo "Building successful!"
-    if $JUST_BUILD; then
-        exit 0
+# Phase 2: Build autocorrect-swift (macOS only, not needed for iOS)
+if [[ "$BUILD_IOS" != true ]]; then
+    echo "Building autocorrect-swift..."
+    mkdir -p build
+    cargo build -p autocorrect-swift --release --target aarch64-apple-darwin --manifest-path=asian-autocorrect/Cargo.toml
+    cp ./asian-autocorrect/target/aarch64-apple-darwin/release/libautocorrect_swift.dylib ./build/libautocorrect_swift.dylib
+    install_name_tool -id "@rpath/libautocorrect_swift.dylib" ./build/libautocorrect_swift.dylib
+    codesign --force --sign - ./build/libautocorrect_swift.dylib
+    if [[ $? -ne 0 ]]; then
+        echo "Cargo build failed!"
+        exit 1
     fi
-    echo "Starting the app..."
-    # Remove quarantine attribute if exists
-    xattr -d com.apple.quarantine ./Build/Build/Products/Debug/OpenSuperWhisper.app 2>/dev/null || true
-    # Run the app and show logs
-    ./Build/Build/Products/Debug/OpenSuperWhisper.app/Contents/MacOS/OpenSuperWhisper
+fi
+
+# Phase 3: Build the app
+if [[ "$BUILD_IOS" == true ]]; then
+    echo "Building OpenSuperWhisper iOS..."
+    xcodebuild -scheme OpenSuperWhisper-iOS \
+        -configuration Debug \
+        -destination 'generic/platform=iOS Simulator' \
+        -derivedDataPath build-ios \
+        -skipPackagePluginValidation -skipMacroValidation \
+        CODE_SIGNING_ALLOWED=NO build
 else
-    echo "Build failed!"
-    exit 1
-fi 
+    echo "Building OpenSuperWhisper..."
+    BUILD_OUTPUT=$(xcodebuild -scheme OpenSuperWhisper -configuration Debug -jobs 8 -derivedDataPath build -quiet -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation -skipMacroValidation -UseModernBuildSystem=YES -clonedSourcePackagesDirPath SourcePackages -skipUnavailableActions CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO OTHER_CODE_SIGN_FLAGS="--entitlements OpenSuperWhisper/OpenSuperWhisper.entitlements" build 2>&1)
+
+    # sudo gem install xcpretty
+    if command -v xcpretty &> /dev/null
+    then
+        echo "$BUILD_OUTPUT" | xcpretty --simple --color
+    else
+        echo "$BUILD_OUTPUT"
+    fi
+
+    # Check if build output contains BUILD FAILED or if the command failed
+    if [[ $? -eq 0 ]] && [[ ! "$BUILD_OUTPUT" =~ "BUILD FAILED" ]]; then
+        echo "Building successful!"
+        if $JUST_BUILD; then
+            exit 0
+        fi
+        echo "Starting the app..."
+        # Remove quarantine attribute if exists
+        xattr -d com.apple.quarantine ./Build/Build/Products/Debug/OpenSuperWhisper.app 2>/dev/null || true
+        # Run the app and show logs
+        ./Build/Build/Products/Debug/OpenSuperWhisper.app/Contents/MacOS/OpenSuperWhisper
+    else
+        echo "Build failed!"
+        exit 1
+    fi
+fi

--- a/run.sh
+++ b/run.sh
@@ -52,6 +52,11 @@ if [[ "$BUILD_IOS" == true ]]; then
         -derivedDataPath build-ios \
         -skipPackagePluginValidation -skipMacroValidation \
         CODE_SIGNING_ALLOWED=NO build
+    if [[ $? -ne 0 ]]; then
+        echo "iOS build failed!"
+        exit 1
+    fi
+    echo "iOS build successful!"
 else
     echo "Building OpenSuperWhisper..."
     BUILD_OUTPUT=$(xcodebuild -scheme OpenSuperWhisper -configuration Debug -jobs 8 -derivedDataPath build -quiet -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation -skipMacroValidation -UseModernBuildSystem=YES -clonedSourcePackagesDirPath SourcePackages -skipUnavailableActions CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO OTHER_CODE_SIGN_FLAGS="--entitlements OpenSuperWhisper/OpenSuperWhisper.entitlements" build 2>&1)


### PR DESCRIPTION
## Summary

- Add `Scripts/build-xcframework.sh` producing a 3-slice dynamic xcframework (macOS arm64, iOS device arm64, iOS simulator arm64+x86_64) with Metal GPU acceleration
- Extract WhisperCore shared framework (27 files) with protocol abstractions (AudioRecording, ClipboardService, TextPostProcessor) for cross-platform code sharing
- Update macOS target to link WhisperCore, replacing cmake libwhisper.a with xcframework
- Add iOS host app target shell (iPhone-only, iOS 17.0, App Groups entitlement)

Part of the [iOS implementation plan](docs/plans/opensuperwhisper-ios-plan.md) — Cycle 1 of 4.

## Key decisions

- Dynamic xcframework (upstream default) with unified 3-slice build
- CoreML deferred — Metal provides GPU acceleration
- FluidAudioEngine decoupled via closure injection (alternateEngineFactory) instead of #if canImport
- Bridge.h simplified to autocorrect-only; whisper access via xcframework module map
- GGML_OPENMP=OFF for all platforms (xcframework consistency)
- Unix Makefiles workaround for CMake 4 + Xcode 26 generator issue

## Known issues

- FluidAudio SPM has pre-existing Swift 6 strict concurrency errors (identical on master) — not caused by this PR
- iOS simulator build requires iOS 26.4 runtime installation (Xcode > Settings > Components)

## Test plan

- [x] xcframework builds with correct 3 slices
- [x] WhisperCore framework compiles to binary (1.4MB)
- [x] macOS target builds without new regressions (FluidAudio errors are pre-existing)
- [x] iOS target shows correct iOS simulator destinations
- [ ] iOS simulator build (requires iOS 26.4 runtime — environment dependency)
- [ ] Full macOS test suite (blocked by pre-existing FluidAudio Swift 6 errors)