### PR TITLE
Default to key combination mode to avoid Input Monitoring permission on first launch

### DIFF
--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -56,8 +56,10 @@ class OnboardingViewModel: ObservableObject {
         
         let currentHotkey = ModifierKey(rawValue: AppPreferences.shared.modifierOnlyHotkey) ?? .none
         if currentHotkey == .none && !AppPreferences.shared.hasCompletedOnboarding {
-            self.selectedShortcut = .rightOption
-            AppPreferences.shared.modifierOnlyHotkey = ModifierKey.rightOption.rawValue
+            // Default to key combination mode — does NOT require Input Monitoring permission.
+            // Users can switch to single modifier key mode later in Settings if they prefer.
+            self.selectedShortcut = .keyCombination
+            AppPreferences.shared.modifierOnlyHotkey = ModifierKey.none.rawValue
             NotificationCenter.default.post(name: .hotkeySettingsChanged, object: nil)
         } else {
             self.selectedShortcut = currentHotkey == .rightOption ? .rightOption : .keyCombination
@@ -407,6 +409,12 @@ struct OnboardingView: View {
                             }
                         }
                         
+                        if viewModel.selectedShortcut == .rightOption {
+                            Text("⚠️ Single modifier key mode requires Input Monitoring permission (macOS needs it to detect modifier keys globally). Only modifier key events are monitored — no regular keystrokes.")
+                                .font(.caption2)
+                                .foregroundColor(.orange)
+                        }
+
                         Text("You can change this later in Settings")
                             .font(.caption2)
                             .foregroundColor(Color(.tertiaryLabelColor))

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1102,6 +1102,11 @@ struct SettingsView: View {
                                 Text("One-tap to toggle recording")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
+
+                                Text("⚠️ This mode requires Input Monitoring permission. macOS requires this to detect single modifier key presses globally. Only modifier key events (⌘, ⌥, ⇧, ⌃, Fn) are monitored — no regular keystrokes are captured.")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                                    .padding(.top, 4)
                             }
                         } else {
                             VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## Summary

- Default onboarding to key combination mode (⌥+~) instead of single modifier key (Right ⌥)
- Add warning text explaining Input Monitoring when users opt into single modifier mode
- No functionality removed — single modifier key mode is still fully supported as opt-in

## Problem

When a new user launches OpenSuperWhisper for the first time, onboarding defaults to "Right ⌥" (single modifier key) mode. This immediately triggers the macOS **Input Monitoring** permission dialog, which asks to "receive keystrokes from any application."

For users unfamiliar with why a dictation app needs this, it looks like a keylogger. I was one of those users — I installed via Homebrew, got the Input Monitoring dialog, and nearly uninstalled.

After reading the source code, I can see that `ModifierKeyMonitor.swift` uses `CGEvent.tapCreate` in **`.listenOnly`** mode monitoring **only `flagsChanged`** events (modifier keys). It's completely safe. But the permission dialog doesn't convey that.

## Solution

**Default to the mode that doesn't need the scary permission.** The `KeyboardShortcuts` library (already used for key combination mode) doesn't require Input Monitoring. New users get a working app with zero trust decisions on first launch.

If users later want single modifier key mode, they can switch in Settings — where a clear warning now explains:
- Why Input Monitoring is required
- What it actually monitors (only modifier keys)
- That no regular keystrokes are captured

Same warning appears in onboarding if someone selects the single modifier option.

## Changes

| File | Change |
|---|---|
| `OnboardingView.swift` | Default `selectedShortcut` to `.keyCombination` instead of `.rightOption` |
| `OnboardingView.swift` | Show warning when single modifier option is selected in onboarding |
| `Settings.swift` | Add explanation text under single modifier key picker |

## Testing

- Fresh install → onboarding defaults to key combination mode → no Input Monitoring dialog
- Switch to single modifier in Settings → warning displayed → permission requested only then
- Existing users with modifier key already set → no change in behavior

🤖 Generated with [Claude Code](https://claude.ai/code)