### PR TITLE
[codex] Add Parakeet word boosting

### DIFF
--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -24,6 +24,7 @@ class FluidAudioEngine: TranscriptionEngine {
         let models = try await AsrModels.downloadAndLoad(version: version)
         let manager = AsrManager(config: .default)
         try await manager.initialize(models: models)
+        await configureCustomVocabulary(on: manager)
         
         asrManager = manager
         asrModels = models
@@ -109,5 +110,40 @@ class FluidAudioEngine: TranscriptionEngine {
         }
         return ["en", "de", "es", "fr", "it", "pt", "ru", "pl", "nl", "tr", "cs", "ar", "zh", "ja", "hu", "fi", "hr", "sk", "sr", "sl", "uk", "ca", "da", "el", "bg"]
     }
-}
 
+    private func configureCustomVocabulary(on manager: AsrManager) async {
+        let vocabularyText = AppPreferences.shared.parakeetCustomVocabulary
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !vocabularyText.isEmpty else {
+            manager.disableVocabularyBoosting()
+            return
+        }
+
+        let vocabularyURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenSuperWhisper-ParakeetVocabulary-\(UUID().uuidString)")
+            .appendingPathExtension("txt")
+
+        do {
+            try vocabularyText.write(to: vocabularyURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: vocabularyURL) }
+
+            let vocabularyData = try await CustomVocabularyContext.loadWithCtcTokens(
+                from: vocabularyURL.path
+            )
+
+            guard !vocabularyData.vocab.terms.isEmpty else {
+                manager.disableVocabularyBoosting()
+                return
+            }
+
+            try await manager.configureVocabularyBoosting(
+                vocabulary: vocabularyData.vocab,
+                ctcModels: vocabularyData.models
+            )
+        } catch {
+            manager.disableVocabularyBoosting()
+            print("Parakeet custom vocabulary unavailable: \(error)")
+        }
+    }
+}

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -32,6 +32,12 @@ class SettingsViewModel: ObservableObject {
             initializeFluidAudioModels()
         }
     }
+
+    @Published var parakeetCustomVocabulary: String {
+        didSet {
+            AppPreferences.shared.parakeetCustomVocabulary = parakeetCustomVocabulary
+        }
+    }
     
     @Published var selectedModelURL: URL? {
         didSet {
@@ -146,6 +152,7 @@ class SettingsViewModel: ObservableObject {
         let prefs = AppPreferences.shared
         self.selectedEngine = prefs.selectedEngine
         self.fluidAudioModelVersion = prefs.fluidAudioModelVersion
+        self.parakeetCustomVocabulary = prefs.parakeetCustomVocabulary
         self.selectedLanguage = prefs.whisperLanguage
         self.translateToEnglish = prefs.translateToEnglish
         self.suppressBlankAudio = prefs.suppressBlankAudio
@@ -524,6 +531,7 @@ struct SettingsView: View {
     @State private var isRecordingNewShortcut = false
     @State private var selectedTab = 0
     @State private var previousModelURL: URL?
+    @State private var previousParakeetCustomVocabulary = ""
     
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -565,6 +573,8 @@ struct SettingsView: View {
                         if viewModel.selectedModelURL != previousModelURL, let modelPath = viewModel.selectedModelURL?.path {
                             TranscriptionService.shared.reloadModel(with: modelPath)
                         }
+                    } else if viewModel.parakeetCustomVocabulary != previousParakeetCustomVocabulary {
+                        TranscriptionService.shared.reloadEngine()
                     }
                     dismiss()
                 }
@@ -589,6 +599,7 @@ struct SettingsView: View {
         }
         .onAppear {
             previousModelURL = viewModel.selectedModelURL
+            previousParakeetCustomVocabulary = viewModel.parakeetCustomVocabulary
             if viewModel.selectedEngine == "fluidaudio" {
                 viewModel.initializeFluidAudioModels()
             }
@@ -709,14 +720,11 @@ struct SettingsView: View {
                                 .foregroundColor(.primary)
                                 .padding(.top, 8)
                             
-                            ScrollView {
-                                VStack(spacing: 12) {
-                                    ForEach($viewModel.downloadableFluidAudioModels) { $model in
-                                        FluidAudioModelDownloadItemView(model: $model, viewModel: viewModel)
-                                    }
+                            VStack(spacing: 12) {
+                                ForEach($viewModel.downloadableFluidAudioModels) { $model in
+                                    FluidAudioModelDownloadItemView(model: $model, viewModel: viewModel)
                                 }
                             }
-                            .frame(maxHeight: 200)
                             
                             if viewModel.isDownloading {
                                 VStack(spacing: 8) {
@@ -768,6 +776,37 @@ struct SettingsView: View {
                                     .padding(8)
                                     .background(Color(.textBackgroundColor).opacity(0.5))
                                     .cornerRadius(6)
+                            }
+                            .padding(.top, 8)
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    Text("Boosted Words")
+                                        .font(.subheadline)
+                                    Spacer()
+                                    if !viewModel.parakeetCustomVocabulary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                        Button("Clear") {
+                                            viewModel.parakeetCustomVocabulary = ""
+                                        }
+                                        .buttonStyle(.borderless)
+                                    }
+                                }
+
+                                TextEditor(text: $viewModel.parakeetCustomVocabulary)
+                                    .font(.body)
+                                    .frame(height: 90)
+                                    .padding(6)
+                                    .background(Color(.textBackgroundColor))
+                                    .cornerRadius(6)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                                    )
+                                    .help("One output term per line. Use output: spoken alias, spoken alias for variants.")
+
+                                Text("One output term per line. Use output: spoken alias, spoken alias for variants.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
                             }
                             .padding(.top, 8)
                         }
@@ -1459,4 +1498,3 @@ struct ModelDownloadItemView: View {
         }
     }
 }
-

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -58,6 +58,9 @@ final class AppPreferences {
     
     @UserDefault(key: "fluidAudioModelVersion", defaultValue: "v3")
     var fluidAudioModelVersion: String
+
+    @UserDefault(key: "parakeetCustomVocabulary", defaultValue: "")
+    var parakeetCustomVocabulary: String
     
     @UserDefault(key: "whisperLanguage", defaultValue: "en")
     var whisperLanguage: String

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import Carbon
 import ApplicationServices
 import AVFoundation
+import FluidAudio
 @testable import OpenSuperWhisper
 
 final class OpenSuperWhisperTests: XCTestCase {
@@ -22,6 +23,43 @@ final class OpenSuperWhisperTests: XCTestCase {
     func testPerformanceExample() throws {
         self.measure {
         }
+    }
+}
+
+final class AppPreferencesParakeetVocabularyTests: XCTestCase {
+    func testParakeetCustomVocabularyPersistsMultilineTerms() {
+        let original = AppPreferences.shared.parakeetCustomVocabulary
+        defer {
+            AppPreferences.shared.parakeetCustomVocabulary = original
+        }
+
+        let vocabulary = """
+        mossformer2: moss former 2, moss former 2
+        squeue: S Q, SQ, es queue
+        """
+        AppPreferences.shared.parakeetCustomVocabulary = vocabulary
+
+        XCTAssertEqual(AppPreferences.shared.parakeetCustomVocabulary, vocabulary)
+    }
+
+    func testParakeetCustomVocabularyAcceptsCommaSeparatedAliases() throws {
+        let vocabulary = """
+        mossformer2: moss former 2, moss former 2
+        squeue: S Q, SQ, es queue
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenSuperWhisperTests-\(UUID().uuidString)")
+            .appendingPathExtension("txt")
+        try vocabulary.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let context = try CustomVocabularyContext.loadFromSimpleFormat(from: url)
+
+        XCTAssertEqual(context.terms.count, 2)
+        XCTAssertEqual(context.terms[0].text, "mossformer2")
+        XCTAssertEqual(context.terms[0].aliases, ["moss former 2", "moss former 2"])
+        XCTAssertEqual(context.terms[1].text, "squeue")
+        XCTAssertEqual(context.terms[1].aliases, ["S Q", "SQ", "es queue"])
     }
 }
 

--- a/patches/fluidaudio-vocabulary-rescorer.patch
+++ b/patches/fluidaudio-vocabulary-rescorer.patch
@@ -1,0 +1,23 @@
+diff --git a/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift b/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+--- a/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
++++ b/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+@@ -84,9 +84,9 @@ extension VocabularyRescorer {
+-        // PASS 2: Sort by span length (ascending) then by similarity (descending)
+-        // This ensures shorter spans are preferred when multiple matches overlap
++        // PASS 2: Sort by span length (descending) then by similarity (descending)
++        // This ensures longer spans are preferred when multiple matches overlap
+         let sortedReplacements = pendingReplacements.sorted { a, b in
+             if a.candidate.spanLength != b.candidate.spanLength {
+-                return a.candidate.spanLength < b.candidate.spanLength  // Prefer shorter spans
++                return a.candidate.spanLength > b.candidate.spanLength  // Prefer longer spans
+             }
+             // For same span length, prefer higher similarity
+             return a.similarity > b.similarity
+         }
+diff --git a/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift b/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+--- a/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
++++ b/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+@@ -457,2 +457,3 @@ extension VocabularyRescorer {
+                 for spanLength in minSpan...maxSpan {
++                    guard wordTimings.count >= spanLength else { continue }
+                     for startIdx in 0..<(wordTimings.count - spanLength + 1) {

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,34 @@ if [[ "$1" == "build" ]]; then
     JUST_BUILD=true
 fi
 
+apply_fluidaudio_patches() {
+    local checkout="SourcePackages/checkouts/FluidAudio"
+    local patch_file="patches/fluidaudio-vocabulary-rescorer.patch"
+    local target="$checkout/Sources/FluidAudio/ASR/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift"
+
+    if [[ ! -f "$patch_file" ]]; then
+        echo "Missing FluidAudio patch: $patch_file"
+        exit 1
+    fi
+
+    if [[ ! -f "$target" ]]; then
+        echo "Missing FluidAudio source checkout: $target"
+        exit 1
+    fi
+
+    if grep -q "Prefer longer spans" "$target" && grep -q "wordTimings.count >= spanLength" "$target"; then
+        echo "FluidAudio vocabulary rescorer patch already applied."
+        return
+    fi
+
+    echo "Applying FluidAudio vocabulary rescorer patch..."
+    patch --silent --forward -d "$checkout" -p1 < "$patch_file"
+    if [[ $? -ne 0 ]] && { ! grep -q "Prefer longer spans" "$target" || ! grep -q "wordTimings.count >= spanLength" "$target"; }; then
+        echo "Failed to apply FluidAudio vocabulary rescorer patch."
+        exit 1
+    fi
+}
+
 # Configure libwhisper
 echo "Configuring libwhisper..."
 cmake -G Xcode -B libwhisper/build -S libwhisper
@@ -28,6 +56,16 @@ echo "Copying libomp.dylib..."
 cp /opt/homebrew/opt/libomp/lib/libomp.dylib ./build/libomp.dylib
 install_name_tool -id "@rpath/libomp.dylib" ./build/libomp.dylib
 codesign --force --sign - ./build/libomp.dylib
+
+echo "Resolving Swift packages..."
+RESOLVE_OUTPUT=$(xcodebuild -resolvePackageDependencies -scheme OpenSuperWhisper -derivedDataPath build -clonedSourcePackagesDirPath SourcePackages -skipPackagePluginValidation -skipMacroValidation 2>&1)
+if [[ $? -ne 0 ]]; then
+    echo "$RESOLVE_OUTPUT"
+    echo "Swift package resolution failed!"
+    exit 1
+fi
+
+apply_fluidaudio_patches
 
 # Build the app
 echo "Building OpenSuperWhisper..."
@@ -55,4 +93,4 @@ if [[ $? -eq 0 ]] && [[ ! "$BUILD_OUTPUT" =~ "BUILD FAILED" ]]; then
 else
     echo "Build failed!"
     exit 1
-fi 
+fi


### PR DESCRIPTION
## Summary

- adds a Parakeet boosted-words editor in Model settings and persists the custom vocabulary
- loads the vocabulary through FluidAudio custom vocabulary support when the Parakeet engine initializes
- persists FluidAudio rescorer fixes so longer matching spans win over shorter overlapping spans and short clips do not crash when multi-word aliases are configured
- removes the nested scroll view that was squishing the Parakeet model picker

## Validation

- `git diff --check`
- `xcodebuild test -scheme OpenSuperWhisper -configuration Debug -derivedDataPath build -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation -skipMacroValidation -UseModernBuildSystem=YES -clonedSourcePackagesDirPath SourcePackages -only-testing:OpenSuperWhisperTests/AppPreferencesParakeetVocabularyTests CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO`
- `./run.sh build`
- signed and verified the debug app with `codesign --verify --deep --strict`
- saved-audio probe with a generic boosted entry like `customterm: spoken alias`: base transcript matched the spoken alias, boosted transcript emitted `customterm`
- short one-word saved-audio probe with multi-word boosted aliases configured returned normally instead of crashing
