### PR TITLE
Live (resumable) streaming transcription

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "libwhisper/whisper.cpp"]
 	path = libwhisper/whisper.cpp
 	url = https://github.com/AlexCherrypi/whisper.cpp.git
-	branch = claude/live-transcription-async-quic3v
+	branch = master
 [submodule "asian-autocorrect"]
 	path = asian-autocorrect
 	url = https://github.com/huacnlee/autocorrect

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "libwhisper/whisper.cpp"]
 	path = libwhisper/whisper.cpp
-	url = https://github.com/ggerganov/whisper.cpp
+	url = https://github.com/AlexCherrypi/whisper.cpp.git
+	branch = claude/live-transcription-async-quic3v
 [submodule "asian-autocorrect"]
 	path = asian-autocorrect
 	url = https://github.com/huacnlee/autocorrect

--- a/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "5d9176eb35bcbe009c7b26202f0e92c85ff2dedf",
-        "version" : "0.11.0"
+        "revision" : "7f963cdc43ba89c5993654f1e138047d517a818d",
+        "version" : "0.15.2"
       }
     },
     {

--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -33,7 +33,17 @@ class ContentViewModel: ObservableObject {
     private var recordingStartTime: Date?
     private var durationTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
-    
+
+    // Live, resumable transcription (shared engine with the hotkey indicator). When enabled,
+    // the main-window record button streams transcription during recording and only decodes the
+    // trailing window on stop, instead of a full file pass afterwards.
+    private let streamingEngine = StreamingWhisperEngine.shared
+    private var liveModeActive = false
+    /// Live streaming only applies to the whisper engine and when the user opted in.
+    private var useLiveStreaming: Bool {
+        AppPreferences.shared.liveStreamingEnabled && AppPreferences.shared.selectedEngine == "whisper"
+    }
+
     init() {
         recorder.$isConnecting
             .receive(on: RunLoop.main)
@@ -173,6 +183,21 @@ class ContentViewModel: ObservableObject {
         Task.detached { [recorder] in
             recorder.startRecording()
         }
+
+        // Live streaming runs in parallel to the file recorder (the WAV is still written for
+        // playback / re-transcription); on stop we use the streamed text instead of a file pass.
+        if useLiveStreaming {
+            liveModeActive = true
+            let settings = Settings()
+            streamingEngine.melNormMode = .window
+            Task.detached { [streamingEngine] in
+                do {
+                    try streamingEngine.start(settings: settings)
+                } catch {
+                    print("Live streaming start failed: \(error)")
+                }
+            }
+        }
     }
 
     func startDecoding() {
@@ -182,13 +207,33 @@ class ContentViewModel: ObservableObject {
         
         IndicatorWindowManager.shared.hide()
 
+        let wasLive = liveModeActive
+        liveModeActive = false
+
         if let tempURL = recorder.stopRecording() {
             Task { [weak self] in
                 guard let self = self else { return }
 
                 do {
-                    print("start decoding...")
-                    let text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+                    let text: String
+                    if wasLive {
+                        // Same live/resumable path as the hotkey indicator: transcription is
+                        // streamed during recording, so only the trailing <30s window is decoded
+                        // on stop. Fall back to a file pass if streaming couldn't run.
+                        let result = await Task.detached { [streamingEngine = self.streamingEngine] in
+                            streamingEngine.stop()
+                        }.value
+                        switch result {
+                        case .transcribed(let liveText):
+                            text = liveText
+                        case .unavailable:
+                            print("Live streaming unavailable - falling back to file transcription")
+                            text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+                        }
+                    } else {
+                        print("start decoding...")
+                        text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+                    }
 
                     // Capture the current recording duration
                     let duration = await MainActor.run { self.recordingDuration }

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -23,8 +23,8 @@ class FluidAudioEngine: TranscriptionEngine {
         
         let models = try await AsrModels.downloadAndLoad(version: version)
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
-        
+        try await manager.loadModels(models)
+
         asrManager = manager
         asrModels = models
     }
@@ -73,8 +73,11 @@ class FluidAudioEngine: TranscriptionEngine {
             progressTask = nil
         }
         
-        // Perform actual transcription - FluidAudio will emit progress automatically
-        let result = try await asrManager.transcribe(url)
+        // Perform actual transcription - FluidAudio will emit progress automatically.
+        // FluidAudio 0.15.x requires an explicit decoder state; a fresh one per call is
+        // correct for one-shot file transcription (no cross-call streaming continuity).
+        var decoderState = try TdtDecoderState()
+        let result = try await asrManager.transcribe(url, decoderState: &decoderState)
         
         guard !isCancelled else {
             throw CancellationError()

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -274,6 +274,23 @@ final class StreamingWhisperEngine {
         }
     }
 
+    /// Graceful teardown for app quit: stop capture, then free the whisper context on the
+    /// serial whisper queue. Releasing the context runs `whisper_free`, which frees the
+    /// model's Metal buffers and drains their macOS 15+ residency sets before the GPU
+    /// device is torn down. The free is enqueued on `whisperQueue`, so it never races an
+    /// in-flight decode, and this never blocks the calling (main) thread.
+    func shutdown() async {
+        cancel()
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            whisperQueue.async { [weak self] in
+                self?.context = nil
+                self?.committedSegments = 0
+                self?.runningText = ""
+                cont.resume()
+            }
+        }
+    }
+
     private func removeConfigObserver() {
         if let obs = configObserver {
             NotificationCenter.default.removeObserver(obs)

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -89,7 +89,7 @@ final class StreamingWhisperEngine {
     func start(settings: Settings) throws {
         guard !isRunning else { return }
 
-        self.settings = settings
+        // isCancelled is read on the audio thread before dispatching; clear it up front.
         self.isCancelled = false
 
         let input = audioEngine.inputNode
@@ -102,11 +102,12 @@ final class StreamingWhisperEngine {
         converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
         self.converter = converter
 
-        // Queue the (possibly slow) model load + reset FIRST. Because whisperQueue is
-        // serial, this runs only after any previous recording's finalize has completed
-        // (so the previous result is captured before we reset), and audio appended by
-        // the tap below is processed only after this block — recording starts instantly
-        // without dropping the lead-in, and ordering across recordings is preserved.
+        // Queue the (possibly slow) model load + per-recording state FIRST. Because
+        // whisperQueue is serial, this runs only after any previous recording's finalize
+        // has completed (so its result is captured and it has read ITS settings before we
+        // overwrite them), and audio appended by the tap below is processed only after
+        // this block — recording starts instantly without dropping the lead-in, and
+        // ordering across overlapping recordings is preserved.
         whisperQueue.async { [weak self] in
             guard let self = self else { return }
             do {
@@ -115,6 +116,7 @@ final class StreamingWhisperEngine {
                 print("Streaming model load failed: \(error)")
                 return
             }
+            self.settings = settings
             self.committedSegments = 0
             self.runningText = ""
             self.context?.resumableReset()

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -59,11 +59,23 @@ final class StreamingWhisperEngine {
     // concurrently on the same context, and must never run on the audio render thread.
     private let whisperQueue = DispatchQueue(label: "streaming.whisper", qos: .userInitiated)
 
+    // Touched only on whisperQueue (serialized) — no lock needed.
     private var settings = Settings()
     private var committedSegments = 0
     private var runningText = ""
-    private var isRunning = false
-    private var isCancelled = false
+
+    // Touched from multiple threads (caller, audio render thread, main) — lock-guarded.
+    private let stateLock = NSLock()
+    private var _isRunning = false
+    private var _isCancelled = false
+    private var isRunning: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _isRunning }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _isRunning = newValue }
+    }
+    private var isCancelled: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _isCancelled }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _isCancelled = newValue }
+    }
 
     private let tapBufferSize: AVAudioFrameCount = 4800 // ~100ms
     private var configObserver: NSObjectProtocol?

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -18,10 +18,12 @@ import AVFoundation
 /// NOTE: this engine is self-contained and does not flow through the file-based
 /// `TranscriptionEngine` protocol. It is driven directly by the recording layer.
 ///
-/// It is a shared singleton with ONE serial whisper queue. That single queue is also
-/// what guarantees ordering across back-to-back recordings: appends, finalizes and resets
-/// all run in FIFO order, so recordings are transcribed (and therefore inserted) strictly
-/// in the order they were made. The model is loaded once.
+/// It is a shared singleton with ONE whisper context and ONE serial whisper queue, so it
+/// handles a single recording at a time. Back-to-back recordings are serialized: the engine
+/// graph is guarded by `engineLock`, and a recording's finalize is enqueued (under that lock)
+/// before the next recording's reset is enqueued — so appends/finalizes/resets run in FIFO
+/// order and a recording's text is captured before the next one resets the context. The
+/// model is loaded once.
 final class StreamingWhisperEngine {
 
     static let shared = StreamingWhisperEngine()
@@ -80,6 +82,15 @@ final class StreamingWhisperEngine {
     private let tapBufferSize: AVAudioFrameCount = 4800 // ~100ms
     private var configObserver: NSObjectProtocol?
 
+    // Serializes all AVAudioEngine graph mutations (start/stop/tap/converter/observer) AND the
+    // whisperQueue submission of a recording's reset/finalize. This prevents an overlapping
+    // start (recording B) and stop (recording A) from (1) touching the shared engine
+    // concurrently — CoreAudio is not safe for that — or (2) reordering B's reset ahead of
+    // A's finalize on the whisper queue (which would clear A's text before it is captured).
+    // It is held only across the brief engine mutation / enqueue, NEVER across the whisper
+    // decode, so B's capture is not delayed by A's finalize.
+    private let engineLock = NSLock()
+
     var isModelLoaded: Bool { context != nil }
 
     // MARK: - Lifecycle
@@ -111,17 +122,20 @@ final class StreamingWhisperEngine {
     /// immediately; the model may still be loading — captured audio is buffered on
     /// the serial whisper queue, so no lead-in is lost.
     func start(settings: Settings) throws {
+        engineLock.lock()
+        defer { engineLock.unlock() }
+
         guard !isRunning else { return }
 
         // isCancelled is read on the audio thread before dispatching; clear it up front.
         self.isCancelled = false
 
-        // Queue the (possibly slow) model load + per-recording state FIRST. Because
-        // whisperQueue is serial, this runs only after any previous recording's finalize
-        // has completed (so its result is captured and it has read ITS settings before we
-        // overwrite them), and audio appended by the tap below is processed only after
-        // this block — recording starts instantly without dropping the lead-in, and
-        // ordering across overlapping recordings is preserved.
+        // Queue the (possibly slow) model load + per-recording reset FIRST, under engineLock.
+        // Because whisperQueue is serial and stop() enqueues the previous recording's finalize
+        // under this same lock, this reset is ordered strictly AFTER that finalize — so the
+        // previous recording's text is captured before we clear the context. Audio appended by
+        // the tap below is processed only after this block, so recording starts instantly
+        // without dropping the lead-in.
         whisperQueue.async { [weak self] in
             guard let self = self else { return }
             do {
@@ -136,26 +150,38 @@ final class StreamingWhisperEngine {
             self.context?.resumableReset()
         }
 
-        try configureCapture()
+        do {
+            try configureCapture()
 
-        // Rebuild the tap/converter if the input device or its format changes mid-stream
-        // (e.g. the mic is unplugged). The resumable state is kept, so the stream continues.
-        configObserver = NotificationCenter.default.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: audioEngine,
-            queue: .main
-        ) { [weak self] _ in
-            self?.handleConfigurationChange()
+            // Rebuild the tap/converter if the input device or its format changes mid-stream
+            // (e.g. the mic is unplugged). The resumable state is kept, so the stream continues.
+            configObserver = NotificationCenter.default.addObserver(
+                forName: .AVAudioEngineConfigurationChange,
+                object: audioEngine,
+                queue: .main
+            ) { [weak self] _ in
+                self?.handleConfigurationChange()
+            }
+
+            audioEngine.prepare()
+            try audioEngine.start()
+        } catch {
+            // Roll back partial setup so the shared engine is not left with a dangling tap or
+            // observer that would corrupt the next live session. isRunning stays false, so the
+            // caller's stop() returns .unavailable and the recording falls back to file
+            // transcription instead of being lost.
+            audioEngine.inputNode.removeTap(onBus: 0)
+            removeConfigObserver()
+            throw error
         }
 
-        audioEngine.prepare()
-        try audioEngine.start()
         isRunning = true
     }
 
     /// (Re)installs the input tap and builds a converter matching the current input format.
     /// The tap runs on the audio render thread: it does the cheap format conversion and
     /// hands the samples to the whisper queue.
+    /// MUST be called with `engineLock` held (callers: start() and handleConfigurationChange()).
     private func configureCapture() throws {
         let input = audioEngine.inputNode
         input.removeTap(onBus: 0)
@@ -175,6 +201,8 @@ final class StreamingWhisperEngine {
 
     /// Input device/format changed (e.g. mic unplugged). Rebuild capture and resume.
     private func handleConfigurationChange() {
+        engineLock.lock()
+        defer { engineLock.unlock() }
         guard isRunning else { return }
         do {
             try configureCapture()
@@ -190,6 +218,8 @@ final class StreamingWhisperEngine {
     /// Returns `.unavailable` if streaming never actually ran (start failed or the model
     /// could not be loaded), so the caller can fall back to a file-based pass.
     func stop() -> FinalizeResult {
+        engineLock.lock()
+
         let wasRunning = isRunning
         isRunning = false
         removeConfigObserver()
@@ -199,16 +229,20 @@ final class StreamingWhisperEngine {
         }
 
         // start() failed before the engine ever ran -> nothing was captured.
-        guard wasRunning else { return .unavailable }
-        if isCancelled { return .transcribed(finalText()) }
+        guard wasRunning else { engineLock.unlock(); return .unavailable }
+        if isCancelled { engineLock.unlock(); return .transcribed(finalText()) }
 
-        // Runs after all queued appends, so the whole recording is accounted for. The
-        // final text is captured INSIDE the sync block so the next recording's reset
-        // (also queued) can't clear it first.
+        // Enqueue the finalize WHILE STILL HOLDING engineLock so it is ordered ahead of any
+        // overlapping start()'s reset (which also enqueues under engineLock). The expensive
+        // decode runs on the serial queue AFTER the lock is released below, so the next
+        // recording's engine setup is not blocked by it. The final text is captured INSIDE
+        // the queued block, so the next recording's reset can't clear it first.
+        let done = DispatchSemaphore(value: 0)
         var captured = ""
         var hadContext = false
-        whisperQueue.sync {
-            guard let context = self.context else { return } // model load failed
+        whisperQueue.async { [weak self] in
+            defer { done.signal() }
+            guard let self = self, let context = self.context else { return } // model load failed
             hadContext = true
             var params = self.makeParams()
             // finalize = true: decode the remaining <30s window (padded), like the last
@@ -219,12 +253,18 @@ final class StreamingWhisperEngine {
             }
             captured = self.finalText()
         }
+        engineLock.unlock()
+
+        // Block this (detached) caller until the finalize finishes, without holding engineLock.
+        done.wait()
 
         guard hadContext else { return .unavailable }
         return .transcribed(captured)
     }
 
     func cancel() {
+        engineLock.lock()
+        defer { engineLock.unlock() }
         isCancelled = true
         removeConfigObserver()
         if isRunning {

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -1,0 +1,254 @@
+import Foundation
+import AVFoundation
+
+/// Live, "pipelined" transcription: audio is fed to whisper incrementally while it is
+/// still being recorded, driving whisper's own 30s-window seek loop via the resumable API
+/// (`whisper_append_audio` + `whisper_full_resumable`). Work overlaps with recording, so
+/// when the user stops only the trailing (<30s) window remains to decode.
+///
+/// This is NOT word-by-word real-time: whisper needs a full 30s window before it emits a
+/// block, so committed text advances roughly every ~30s of speech. The benefit is "near
+/// instant on stop" while keeping full large-model quality.
+///
+/// Quality vs. mel normalization:
+///  - `.global` is byte-identical to a single `whisper_full()` pass (batch quality).
+///  - `.window` is an envelope-follower AGC meant for live audio (prevents silence from
+///    amplifying background noise). Recommended default for the live mic path.
+///
+/// NOTE: this engine is self-contained and does not (yet) flow through the file-based
+/// `TranscriptionEngine` protocol. It is driven directly by the recording layer.
+final class StreamingWhisperEngine {
+
+    enum MelNormMode: Int32 {
+        case global = 0
+        case window = 1
+    }
+
+    /// Called on the main actor with the running transcription text after each new block.
+    var onTranscriptionUpdate: ((String) -> Void)?
+
+    /// Mel normalization for the live path. `.window` is recommended for mic input.
+    var melNormMode: MelNormMode = .window
+    /// WINDOW-mode release half-life in seconds of audio time (ignored for `.global`).
+    var melNormHalfLife: Float = 2.0
+
+    private var context: MyWhisperContext?
+
+    private let audioEngine = AVAudioEngine()
+    private var converter: AVAudioConverter?
+    private let targetFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                             sampleRate: 16000,
+                                             channels: 1,
+                                             interleaved: false)
+
+    // All whisper calls (append + resumable) are serialized here; they must never run
+    // concurrently on the same context, and must never run on the audio render thread.
+    private let whisperQueue = DispatchQueue(label: "streaming.whisper", qos: .userInitiated)
+
+    private var settings = Settings()
+    private var committedSegments = 0
+    private var runningText = ""
+    private var isRunning = false
+    private var isCancelled = false
+
+    var isModelLoaded: Bool { context != nil }
+
+    // MARK: - Lifecycle
+
+    func initialize() throws {
+        let modelPath = AppPreferences.shared.selectedWhisperModelPath ?? AppPreferences.shared.selectedModelPath
+        guard let modelPath = modelPath else {
+            throw TranscriptionError.contextInitializationFailed
+        }
+        let params = WhisperContextParams()
+        context = MyWhisperContext.initFromFile(path: modelPath, params: params)
+        guard context != nil else {
+            throw TranscriptionError.contextInitializationFailed
+        }
+    }
+
+    /// Begin capturing from the default input and transcribing live.
+    func start(settings: Settings) throws {
+        guard let context = context else {
+            throw TranscriptionError.contextInitializationFailed
+        }
+        guard !isRunning else { return }
+
+        self.settings = settings
+        self.committedSegments = 0
+        self.runningText = ""
+        self.isCancelled = false
+
+        whisperQueue.sync {
+            context.resumableReset()
+        }
+
+        let input = audioEngine.inputNode
+        let inputFormat = input.inputFormat(forBus: 0)
+
+        guard let targetFormat = targetFormat,
+              let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            throw TranscriptionError.audioConversionFailed
+        }
+        converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
+        self.converter = converter
+
+        // ~100ms buffers. The tap runs on the audio render thread: do the cheap
+        // format conversion here, then hand the samples to the whisper queue.
+        let tapBufferSize: AVAudioFrameCount = 4800
+        input.installTap(onBus: 0, bufferSize: tapBufferSize, format: inputFormat) { [weak self] buffer, _ in
+            self?.handleIncoming(buffer: buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+        isRunning = true
+    }
+
+    /// Stop capturing, flush the trailing window, and return the final transcription.
+    func stop() -> String {
+        guard isRunning else { return finalText() }
+        isRunning = false
+
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+
+        guard let context = context, !isCancelled else { return finalText() }
+
+        whisperQueue.sync {
+            var params = self.makeParams()
+            // finalize = true: decode the remaining <30s window (padded), like the last
+            // iteration of whisper_full's internal loop.
+            let nNew = context.fullResumable(params: &params, finalize: true)
+            if nNew > 0 {
+                self.appendNewSegments(from: context)
+            }
+        }
+        return finalText()
+    }
+
+    func cancel() {
+        isCancelled = true
+        if isRunning {
+            isRunning = false
+            audioEngine.inputNode.removeTap(onBus: 0)
+            audioEngine.stop()
+        }
+    }
+
+    // MARK: - Audio pipeline
+
+    private func handleIncoming(buffer: AVAudioPCMBuffer) {
+        guard let converter = converter, let targetFormat = targetFormat, !isCancelled else { return }
+
+        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 256
+        guard let outBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return }
+
+        var consumed = false
+        var convError: NSError?
+        let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        outBuffer.frameLength = 0
+        converter.convert(to: outBuffer, error: &convError, withInputFrom: inputBlock)
+        if convError != nil { return }
+
+        let frames = Int(outBuffer.frameLength)
+        guard frames > 0, let channel = outBuffer.floatChannelData?[0] else { return }
+        let samples = Array(UnsafeBufferPointer(start: channel, count: frames))
+
+        // Hand off to the serialized whisper queue. Appends are cheap; the expensive
+        // decode only happens inside fullResumable once a full 30s window is available.
+        whisperQueue.async { [weak self] in
+            guard let self = self, let context = self.context, !self.isCancelled else { return }
+            _ = context.appendAudio(samples: samples)
+
+            var params = self.makeParams()
+            let nNew = context.fullResumable(params: &params, finalize: false)
+            if nNew > 0 {
+                self.appendNewSegments(from: context)
+            }
+        }
+    }
+
+    // MARK: - Results
+
+    /// Reads segments [committedSegments ..< total) and appends them to runningText.
+    /// Must be called on whisperQueue.
+    private func appendNewSegments(from context: MyWhisperContext) {
+        let total = context.fullNSegments
+        guard total > committedSegments else { return }
+
+        for i in committedSegments..<total {
+            guard let segmentText = context.fullGetSegmentText(iSegment: i) else { continue }
+            if settings.showTimestamps {
+                let t0 = context.fullGetSegmentT0(iSegment: i)
+                let t1 = context.fullGetSegmentT1(iSegment: i)
+                runningText += String(format: "[%.1f->%.1f] ", Float(t0) / 100.0, Float(t1) / 100.0)
+            }
+            runningText += segmentText
+        }
+        committedSegments = total
+
+        let snapshot = cleaned(runningText)
+        DispatchQueue.main.async { [weak self] in
+            self?.onTranscriptionUpdate?(snapshot)
+        }
+    }
+
+    private func finalText() -> String {
+        let text = cleaned(runningText)
+        return text.isEmpty ? "No speech detected in the audio" : text
+    }
+
+    private func cleaned(_ text: String) -> String {
+        var result = text
+            .replacingOccurrences(of: "[MUSIC]", with: "")
+            .replacingOccurrences(of: "[BLANK_AUDIO]", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if settings.shouldApplyAsianAutocorrect && !result.isEmpty {
+            result = AutocorrectWrapper.format(result)
+        }
+        return result
+    }
+
+    // MARK: - Params
+
+    private func makeParams() -> whisper_full_params {
+        let nThreads = max(2, min(ProcessInfo.processInfo.activeProcessorCount, 8))
+
+        var params = WhisperFullParams()
+        params.strategy = settings.useBeamSearch ? .beamSearch : .greedy
+        params.nThreads = Int32(nThreads)
+        params.noTimestamps = !settings.showTimestamps
+        params.suppressBlank = settings.suppressBlankAudio
+        params.translate = settings.translateToEnglish
+        let isAutoDetect = settings.selectedLanguage == "auto"
+        params.language = isAutoDetect ? nil : settings.selectedLanguage
+        params.detectLanguage = false
+        params.temperature = Float(settings.temperature)
+        params.noSpeechThold = Float(settings.noSpeechThreshold)
+        params.initialPrompt = settings.initialPrompt.isEmpty ? nil : settings.initialPrompt
+        if settings.useBeamSearch {
+            params.beamSearchBeamSize = Int32(settings.beamSize)
+        }
+
+        // The resumable API manages cross-window seek + context itself, so we don't
+        // print realtime or feed prompt tokens manually.
+        params.printRealtime = false
+        params.print_realtime = false
+
+        params.melNormMode = melNormMode.rawValue
+        params.melNormHalfLife = melNormHalfLife
+
+        return params.toC()
+    }
+}

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -381,10 +381,13 @@ final class StreamingWhisperEngine {
             params.beamSearchBeamSize = Int32(settings.beamSize)
         }
 
-        // The resumable API manages cross-window seek + context itself, so we don't
-        // print realtime or feed prompt tokens manually.
-        params.printRealtime = false
-        params.print_realtime = false
+        // The resumable API manages cross-window seek + context itself, so we never feed
+        // prompt tokens manually. Realtime segment printing (whisper -> stderr) is gated on
+        // the app's debug setting, matching the file path's verbosity when logging is on and
+        // staying quiet otherwise.
+        let verbose = AppPreferences.shared.debugMode
+        params.printRealtime = verbose
+        params.print_realtime = verbose
 
         params.melNormMode = melNormMode.rawValue
         params.melNormHalfLife = melNormHalfLife

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -388,6 +388,15 @@ final class StreamingWhisperEngine {
         let verbose = AppPreferences.shared.debugMode
         params.printRealtime = verbose
         params.print_realtime = verbose
+        if verbose {
+            // Debug logging on: compute real segment timestamps so the realtime log shows valid
+            // [t0 --> t1] times instead of a bogus header built from an unset timestamp token.
+            // The stored transcription text still follows settings.showTimestamps; this only
+            // affects the log (and adds timestamp tokens to decoding while debugging).
+            params.noTimestamps = false
+        }
+        // Only print the [t0 --> t1] header when timestamps are actually computed.
+        params.printTimestamps = verbose || settings.showTimestamps
 
         params.melNormMode = melNormMode.rawValue
         params.melNormHalfLife = melNormHalfLife

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -32,6 +32,15 @@ final class StreamingWhisperEngine {
         case window = 1
     }
 
+    /// Outcome of finalizing a streaming session.
+    enum FinalizeResult {
+        /// Streaming ran; the text is the transcription (may be a "no speech" placeholder).
+        case transcribed(String)
+        /// Streaming could never run (no model / mic / start error). The caller should
+        /// fall back to a file-based transcription so the recording is not lost.
+        case unavailable
+    }
+
     /// Mel normalization for the live path. `.window` is recommended for mic input.
     var melNormMode: MelNormMode = .window
     /// WINDOW-mode release half-life in seconds of audio time (ignored for `.global`).
@@ -135,21 +144,28 @@ final class StreamingWhisperEngine {
     }
 
     /// Stop capturing, flush the trailing window, and return the final transcription.
-    func stop() -> String {
-        guard isRunning else { return finalText() }
+    /// Returns `.unavailable` if streaming never actually ran (start failed or the model
+    /// could not be loaded), so the caller can fall back to a file-based pass.
+    func stop() -> FinalizeResult {
+        let wasRunning = isRunning
         isRunning = false
+        if wasRunning {
+            audioEngine.inputNode.removeTap(onBus: 0)
+            audioEngine.stop()
+        }
 
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
-
-        guard !isCancelled else { return finalText() }
+        // start() failed before the engine ever ran -> nothing was captured.
+        guard wasRunning else { return .unavailable }
+        if isCancelled { return .transcribed(finalText()) }
 
         // Runs after all queued appends, so the whole recording is accounted for. The
         // final text is captured INSIDE the sync block so the next recording's reset
         // (also queued) can't clear it first.
         var captured = ""
+        var hadContext = false
         whisperQueue.sync {
-            guard let context = self.context else { return }
+            guard let context = self.context else { return } // model load failed
+            hadContext = true
             var params = self.makeParams()
             // finalize = true: decode the remaining <30s window (padded), like the last
             // iteration of whisper_full's internal loop.
@@ -159,7 +175,9 @@ final class StreamingWhisperEngine {
             }
             captured = self.finalText()
         }
-        return captured.isEmpty ? "No speech detected in the audio" : captured
+
+        guard hadContext else { return .unavailable }
+        return .transcribed(captured)
     }
 
     func cancel() {

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -65,6 +65,9 @@ final class StreamingWhisperEngine {
     private var isRunning = false
     private var isCancelled = false
 
+    private let tapBufferSize: AVAudioFrameCount = 4800 // ~100ms
+    private var configObserver: NSObjectProtocol?
+
     var isModelLoaded: Bool { context != nil }
 
     // MARK: - Lifecycle
@@ -101,16 +104,6 @@ final class StreamingWhisperEngine {
         // isCancelled is read on the audio thread before dispatching; clear it up front.
         self.isCancelled = false
 
-        let input = audioEngine.inputNode
-        let inputFormat = input.inputFormat(forBus: 0)
-
-        guard let targetFormat = targetFormat,
-              let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-            throw TranscriptionError.audioConversionFailed
-        }
-        converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
-        self.converter = converter
-
         // Queue the (possibly slow) model load + per-recording state FIRST. Because
         // whisperQueue is serial, this runs only after any previous recording's finalize
         // has completed (so its result is captured and it has read ITS settings before we
@@ -131,16 +124,54 @@ final class StreamingWhisperEngine {
             self.context?.resumableReset()
         }
 
-        // ~100ms buffers. The tap runs on the audio render thread: do the cheap
-        // format conversion here, then hand the samples to the whisper queue.
-        let tapBufferSize: AVAudioFrameCount = 4800
-        input.installTap(onBus: 0, bufferSize: tapBufferSize, format: inputFormat) { [weak self] buffer, _ in
-            self?.handleIncoming(buffer: buffer)
+        try configureCapture()
+
+        // Rebuild the tap/converter if the input device or its format changes mid-stream
+        // (e.g. the mic is unplugged). The resumable state is kept, so the stream continues.
+        configObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: audioEngine,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleConfigurationChange()
         }
 
         audioEngine.prepare()
         try audioEngine.start()
         isRunning = true
+    }
+
+    /// (Re)installs the input tap and builds a converter matching the current input format.
+    /// The tap runs on the audio render thread: it does the cheap format conversion and
+    /// hands the samples to the whisper queue.
+    private func configureCapture() throws {
+        let input = audioEngine.inputNode
+        input.removeTap(onBus: 0)
+
+        let inputFormat = input.inputFormat(forBus: 0)
+        guard let targetFormat = targetFormat,
+              let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            throw TranscriptionError.audioConversionFailed
+        }
+        converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
+        self.converter = converter
+
+        input.installTap(onBus: 0, bufferSize: tapBufferSize, format: inputFormat) { [weak self] buffer, _ in
+            self?.handleIncoming(buffer: buffer)
+        }
+    }
+
+    /// Input device/format changed (e.g. mic unplugged). Rebuild capture and resume.
+    private func handleConfigurationChange() {
+        guard isRunning else { return }
+        do {
+            try configureCapture()
+            if !audioEngine.isRunning {
+                try audioEngine.start()
+            }
+        } catch {
+            print("Streaming reconfigure after device change failed: \(error)")
+        }
     }
 
     /// Stop capturing, flush the trailing window, and return the final transcription.
@@ -149,6 +180,7 @@ final class StreamingWhisperEngine {
     func stop() -> FinalizeResult {
         let wasRunning = isRunning
         isRunning = false
+        removeConfigObserver()
         if wasRunning {
             audioEngine.inputNode.removeTap(onBus: 0)
             audioEngine.stop()
@@ -182,10 +214,18 @@ final class StreamingWhisperEngine {
 
     func cancel() {
         isCancelled = true
+        removeConfigObserver()
         if isRunning {
             isRunning = false
             audioEngine.inputNode.removeTap(onBus: 0)
             audioEngine.stop()
+        }
+    }
+
+    private func removeConfigObserver() {
+        if let obs = configObserver {
+            NotificationCenter.default.removeObserver(obs)
+            configObserver = nil
         }
     }
 

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -15,17 +15,22 @@ import AVFoundation
 ///  - `.window` is an envelope-follower AGC meant for live audio (prevents silence from
 ///    amplifying background noise). Recommended default for the live mic path.
 ///
-/// NOTE: this engine is self-contained and does not (yet) flow through the file-based
+/// NOTE: this engine is self-contained and does not flow through the file-based
 /// `TranscriptionEngine` protocol. It is driven directly by the recording layer.
+///
+/// It is a shared singleton with ONE serial whisper queue. That single queue is also
+/// what guarantees ordering across back-to-back recordings: appends, finalizes and resets
+/// all run in FIFO order, so recordings are transcribed (and therefore inserted) strictly
+/// in the order they were made. The model is loaded once.
 final class StreamingWhisperEngine {
+
+    static let shared = StreamingWhisperEngine()
+    private init() {}
 
     enum MelNormMode: Int32 {
         case global = 0
         case window = 1
     }
-
-    /// Called on the main actor with the running transcription text after each new block.
-    var onTranscriptionUpdate: ((String) -> Void)?
 
     /// Mel normalization for the live path. `.window` is recommended for mic input.
     var melNormMode: MelNormMode = .window
@@ -85,8 +90,6 @@ final class StreamingWhisperEngine {
         guard !isRunning else { return }
 
         self.settings = settings
-        self.committedSegments = 0
-        self.runningText = ""
         self.isCancelled = false
 
         let input = audioEngine.inputNode
@@ -100,8 +103,10 @@ final class StreamingWhisperEngine {
         self.converter = converter
 
         // Queue the (possibly slow) model load + reset FIRST. Because whisperQueue is
-        // serial, audio appended by the tap below is only processed after this block
-        // runs — so recording can start instantly without dropping the lead-in.
+        // serial, this runs only after any previous recording's finalize has completed
+        // (so the previous result is captured before we reset), and audio appended by
+        // the tap below is processed only after this block — recording starts instantly
+        // without dropping the lead-in, and ordering across recordings is preserved.
         whisperQueue.async { [weak self] in
             guard let self = self else { return }
             do {
@@ -110,6 +115,8 @@ final class StreamingWhisperEngine {
                 print("Streaming model load failed: \(error)")
                 return
             }
+            self.committedSegments = 0
+            self.runningText = ""
             self.context?.resumableReset()
         }
 
@@ -135,7 +142,10 @@ final class StreamingWhisperEngine {
 
         guard !isCancelled else { return finalText() }
 
-        // Runs after all queued appends, so the whole recording is accounted for.
+        // Runs after all queued appends, so the whole recording is accounted for. The
+        // final text is captured INSIDE the sync block so the next recording's reset
+        // (also queued) can't clear it first.
+        var captured = ""
         whisperQueue.sync {
             guard let context = self.context else { return }
             var params = self.makeParams()
@@ -145,8 +155,9 @@ final class StreamingWhisperEngine {
             if nNew > 0 {
                 self.appendNewSegments(from: context)
             }
+            captured = self.finalText()
         }
-        return finalText()
+        return captured.isEmpty ? "No speech detected in the audio" : captured
     }
 
     func cancel() {
@@ -219,11 +230,6 @@ final class StreamingWhisperEngine {
             runningText += segmentText
         }
         committedSegments = total
-
-        let snapshot = cleaned(runningText)
-        DispatchQueue.main.async { [weak self] in
-            self?.onTranscriptionUpdate?(snapshot)
-        }
     }
 
     private func finalText() -> String {

--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -55,33 +55,39 @@ final class StreamingWhisperEngine {
 
     // MARK: - Lifecycle
 
+    /// Optional preload so the model is hot before the first recording.
     func initialize() throws {
+        var thrown: Error?
+        whisperQueue.sync {
+            do { try self.loadContextIfNeeded() } catch { thrown = error }
+        }
+        if let thrown = thrown { throw thrown }
+    }
+
+    /// Loads the whisper context if not already loaded. Must run on whisperQueue.
+    private func loadContextIfNeeded() throws {
+        if context != nil { return }
         let modelPath = AppPreferences.shared.selectedWhisperModelPath ?? AppPreferences.shared.selectedModelPath
         guard let modelPath = modelPath else {
             throw TranscriptionError.contextInitializationFailed
         }
         let params = WhisperContextParams()
-        context = MyWhisperContext.initFromFile(path: modelPath, params: params)
-        guard context != nil else {
+        guard let ctx = MyWhisperContext.initFromFile(path: modelPath, params: params) else {
             throw TranscriptionError.contextInitializationFailed
         }
+        context = ctx
     }
 
-    /// Begin capturing from the default input and transcribing live.
+    /// Begin capturing from the default input and transcribing live. Returns
+    /// immediately; the model may still be loading — captured audio is buffered on
+    /// the serial whisper queue, so no lead-in is lost.
     func start(settings: Settings) throws {
-        guard let context = context else {
-            throw TranscriptionError.contextInitializationFailed
-        }
         guard !isRunning else { return }
 
         self.settings = settings
         self.committedSegments = 0
         self.runningText = ""
         self.isCancelled = false
-
-        whisperQueue.sync {
-            context.resumableReset()
-        }
 
         let input = audioEngine.inputNode
         let inputFormat = input.inputFormat(forBus: 0)
@@ -92,6 +98,20 @@ final class StreamingWhisperEngine {
         }
         converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
         self.converter = converter
+
+        // Queue the (possibly slow) model load + reset FIRST. Because whisperQueue is
+        // serial, audio appended by the tap below is only processed after this block
+        // runs — so recording can start instantly without dropping the lead-in.
+        whisperQueue.async { [weak self] in
+            guard let self = self else { return }
+            do {
+                try self.loadContextIfNeeded()
+            } catch {
+                print("Streaming model load failed: \(error)")
+                return
+            }
+            self.context?.resumableReset()
+        }
 
         // ~100ms buffers. The tap runs on the audio render thread: do the cheap
         // format conversion here, then hand the samples to the whisper queue.
@@ -113,9 +133,11 @@ final class StreamingWhisperEngine {
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
 
-        guard let context = context, !isCancelled else { return finalText() }
+        guard !isCancelled else { return finalText() }
 
+        // Runs after all queued appends, so the whole recording is accounted for.
         whisperQueue.sync {
+            guard let context = self.context else { return }
             var params = self.makeParams()
             // finalize = true: decode the remaining <30s window (padded), like the last
             // iteration of whisper_full's internal loop.

--- a/OpenSuperWhisper/Engines/WhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/WhisperEngine.swift
@@ -160,7 +160,15 @@ class WhisperEngine: TranscriptionEngine {
         
         params.printRealtime = true
         params.print_realtime = true
-        
+        // When debug logging is on, compute real timestamps so the realtime log shows valid
+        // [t0 --> t1] times; otherwise only print the header when the user enabled timestamps
+        // (a header without computed timestamps renders as a bogus negative time).
+        let verboseLog = AppPreferences.shared.debugMode
+        if verboseLog {
+            params.noTimestamps = false
+        }
+        params.printTimestamps = verboseLog || settings.showTimestamps
+
         var cParams = params.toC()
         cParams.abort_callback = abortCallback
         

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -124,9 +124,8 @@ class IndicatorViewModel: ObservableObject {
             }
             Task.detached { [streamingEngine] in
                 do {
-                    if !streamingEngine.isModelLoaded {
-                        try streamingEngine.initialize()
-                    }
+                    // start() loads the model on its serial queue and buffers audio
+                    // meanwhile, so recording is instant and no lead-in is lost.
                     try streamingEngine.start(settings: settings)
                 } catch {
                     print("Live streaming start failed: \(error)")

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -12,8 +12,8 @@ enum RecordingState {
 
 @MainActor
 protocol IndicatorViewDelegate: AnyObject {
-    
-    func didFinishDecoding()
+
+    func didFinishDecoding(for viewModel: IndicatorViewModel)
 }
 
 @MainActor
@@ -22,10 +22,8 @@ class IndicatorViewModel: ObservableObject {
     @Published var isBlinking = false
     @Published var recorder: AudioRecorder = .shared
     @Published var isVisible = false
-    /// Running transcription text while live streaming is active.
-    @Published var liveText: String = ""
 
-    private let streamingEngine = StreamingWhisperEngine()
+    private let streamingEngine = StreamingWhisperEngine.shared
     private var liveModeActive = false
 
     /// Live streaming only applies to the whisper engine and when the user opted in.
@@ -88,17 +86,22 @@ class IndicatorViewModel: ObservableObject {
         hideTimer?.invalidate()
         hideTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
             Task { @MainActor in
-                self?.delegate?.didFinishDecoding()
+                guard let self = self else { return }
+                self.delegate?.didFinishDecoding(for: self)
             }
         }
     }
     
     func startRecording() {
-        if isTranscriptionBusy {
+        // In live mode the streaming engine has its own serial queue and a separate
+        // context, so a new recording can start while a previous one is still
+        // finalizing/transcribing — work is queued, not blocked. The file path shares
+        // a single context, so it must still block to avoid concurrent whisper_full.
+        if !useLiveStreaming && isTranscriptionBusy {
             showBusyMessage()
             return
         }
-        
+
         if MicrophoneService.shared.isActiveMicrophoneRequiresConnection() {
             state = .connecting
             stopBlinking()
@@ -106,7 +109,7 @@ class IndicatorViewModel: ObservableObject {
             state = .recording
             startBlinking()
         }
-        
+
         Task.detached { [recorder] in
             recorder.startRecording()
         }
@@ -116,12 +119,8 @@ class IndicatorViewModel: ObservableObject {
         // text instead of a fresh file-based pass.
         if useLiveStreaming {
             liveModeActive = true
-            liveText = ""
             let settings = Settings()
             streamingEngine.melNormMode = .window
-            streamingEngine.onTranscriptionUpdate = { [weak self] text in
-                Task { @MainActor in self?.liveText = text }
-            }
             Task.detached { [streamingEngine] in
                 do {
                     // start() loads the model on its serial queue and buffers audio
@@ -137,34 +136,34 @@ class IndicatorViewModel: ObservableObject {
     func startDecoding() {
         stopBlinking()
         
+        // Live mode never blocks: the streaming engine queues this finalize behind any
+        // previous one (serial queue), so recordings are finalized and inserted strictly
+        // in the order they were made.
+        if liveModeActive {
+            liveModeActive = false
+            state = .decoding
+            let tempURL = recorder.stopRecording()
+            Task { [weak self] in
+                guard let self = self else { return }
+                // Flush the trailing <30s window off the main actor. stop() blocks on the
+                // engine's serial queue, so it waits for the previous recording's finalize
+                // -> ordered transcription + ordered insertion.
+                let text = await Task.detached { [streamingEngine = self.streamingEngine] in
+                    streamingEngine.stop()
+                }.value
+                await self.persist(text: text, tempURL: tempURL)
+                self.delegate?.didFinishDecoding(for: self)
+            }
+            return
+        }
+
         if isTranscriptionBusy {
             recorder.cancelRecording()
-            if liveModeActive {
-                streamingEngine.cancel()
-                liveModeActive = false
-                liveText = ""
-            }
             showBusyMessage()
             return
         }
 
         state = .decoding
-
-        if liveModeActive {
-            liveModeActive = false
-            let tempURL = recorder.stopRecording()
-            Task { [weak self] in
-                guard let self = self else { return }
-                // Flush the trailing <30s window off the main actor.
-                let text = await Task.detached { [streamingEngine = self.streamingEngine] in
-                    streamingEngine.stop()
-                }.value
-                self.liveText = ""
-                await self.persist(text: text, tempURL: tempURL)
-                self.delegate?.didFinishDecoding()
-            }
-            return
-        }
 
         if let tempURL = recorder.stopRecording() {
             Task { [weak self] in
@@ -214,7 +213,7 @@ class IndicatorViewModel: ObservableObject {
                 }
                 
                 await MainActor.run {
-                    self.delegate?.didFinishDecoding()
+                    self.delegate?.didFinishDecoding(for: self)
                 }
             }
         } else {
@@ -223,7 +222,7 @@ class IndicatorViewModel: ObservableObject {
             
             Task {
                 await MainActor.run {
-                    self.delegate?.didFinishDecoding()
+                    self.delegate?.didFinishDecoding(for: self)
                 }
             }
         }
@@ -327,7 +326,6 @@ class IndicatorViewModel: ObservableObject {
         if liveModeActive {
             streamingEngine.cancel()
             liveModeActive = false
-            liveText = ""
         }
     }
 

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -93,10 +93,11 @@ class IndicatorViewModel: ObservableObject {
     }
     
     func startRecording() {
-        // In live mode the streaming engine has its own serial queue and a separate
-        // context, so a new recording can start while a previous one is still
-        // finalizing/transcribing — work is queued, not blocked. The file path shares
-        // a single context, so it must still block to avoid concurrent whisper_full.
+        // In live mode the streaming engine serializes back-to-back recordings on its own
+        // queue (guarded by engineLock): a new recording can start while a previous one is
+        // still finalizing — the new reset is queued strictly after the previous finalize,
+        // so work is ordered, not blocked. The file path shares a single context, so it must
+        // still block to avoid concurrent whisper_full.
         if !useLiveStreaming && isTranscriptionBusy {
             showBusyMessage()
             return

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -22,7 +22,17 @@ class IndicatorViewModel: ObservableObject {
     @Published var isBlinking = false
     @Published var recorder: AudioRecorder = .shared
     @Published var isVisible = false
-    
+    /// Running transcription text while live streaming is active.
+    @Published var liveText: String = ""
+
+    private let streamingEngine = StreamingWhisperEngine()
+    private var liveModeActive = false
+
+    /// Live streaming only applies to the whisper engine and when the user opted in.
+    private var useLiveStreaming: Bool {
+        AppPreferences.shared.liveStreamingEnabled && AppPreferences.shared.selectedEngine == "whisper"
+    }
+
     var delegate: IndicatorViewDelegate?
     private var blinkTimer: Timer?
     private var hideTimer: Timer?
@@ -58,6 +68,14 @@ class IndicatorViewModel: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        // Warm up the streaming model so the tap can start immediately on record
+        // (otherwise model load would drop the lead-in of the live transcription).
+        if useLiveStreaming {
+            Task.detached { [streamingEngine] in
+                try? streamingEngine.initialize()
+            }
+        }
     }
     
     var isTranscriptionBusy: Bool {
@@ -92,19 +110,63 @@ class IndicatorViewModel: ObservableObject {
         Task.detached { [recorder] in
             recorder.startRecording()
         }
+
+        // Live streaming runs in parallel to the file recorder: the WAV is still
+        // written (playback / re-transcribe stay intact); on stop we use the live
+        // text instead of a fresh file-based pass.
+        if useLiveStreaming {
+            liveModeActive = true
+            liveText = ""
+            let settings = Settings()
+            streamingEngine.melNormMode = .window
+            streamingEngine.onTranscriptionUpdate = { [weak self] text in
+                Task { @MainActor in self?.liveText = text }
+            }
+            Task.detached { [streamingEngine] in
+                do {
+                    if !streamingEngine.isModelLoaded {
+                        try streamingEngine.initialize()
+                    }
+                    try streamingEngine.start(settings: settings)
+                } catch {
+                    print("Live streaming start failed: \(error)")
+                }
+            }
+        }
     }
-    
+
     func startDecoding() {
         stopBlinking()
         
         if isTranscriptionBusy {
             recorder.cancelRecording()
+            if liveModeActive {
+                streamingEngine.cancel()
+                liveModeActive = false
+                liveText = ""
+            }
             showBusyMessage()
             return
         }
-        
+
         state = .decoding
-        
+
+        if liveModeActive {
+            liveModeActive = false
+            let tempURL = recorder.stopRecording()
+            Task { [weak self] in
+                guard let self = self else { return }
+                // Flush the trailing <30s window off the main actor.
+                let text = await Task.detached { [streamingEngine = self.streamingEngine] in
+                    streamingEngine.stop()
+                }.value
+                self.liveText = ""
+                await self.persist(text: text, tempURL: tempURL)
+                self.delegate?.didFinishDecoding()
+            }
+            return
+        }
+
         if let tempURL = recorder.stopRecording() {
             Task { [weak self] in
                 guard let self = self else { return }
@@ -168,6 +230,44 @@ class IndicatorViewModel: ObservableObject {
         }
     }
     
+    /// Saves the transcription (moving the recorded WAV to its final location when present)
+    /// and inserts/copies the text. Used by the live streaming path.
+    private func persist(text: String, tempURL: URL?) async {
+        if let tempURL = tempURL {
+            let timestamp = Date()
+            let fileName = "\(Int(timestamp.timeIntervalSince1970)).wav"
+            let recordingId = UUID()
+            let finalURL = Recording(
+                id: recordingId,
+                timestamp: timestamp,
+                fileName: fileName,
+                transcription: text,
+                duration: 0,
+                status: .completed,
+                progress: 1.0,
+                sourceFileURL: nil
+            ).url
+
+            do {
+                try recorder.moveTemporaryRecording(from: tempURL, to: finalURL)
+                self.recordingStore.addRecording(Recording(
+                    id: recordingId,
+                    timestamp: timestamp,
+                    fileName: fileName,
+                    transcription: text,
+                    duration: 0,
+                    status: .completed,
+                    progress: 1.0,
+                    sourceFileURL: nil
+                ))
+            } catch {
+                print("Error saving live recording: \(error)")
+                try? FileManager.default.removeItem(at: tempURL)
+            }
+        }
+        insertText(text)
+    }
+
     func insertText(_ text: String) {
         let finalText = Self.applyPostProcessing(text)
         let prefs = AppPreferences.shared
@@ -225,6 +325,11 @@ class IndicatorViewModel: ObservableObject {
         hideTimer?.invalidate()
         hideTimer = nil
         recorder.cancelRecording()
+        if liveModeActive {
+            streamingEngine.cancel()
+            liveModeActive = false
+            liveText = ""
+        }
     }
 
     @MainActor

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -148,10 +148,18 @@ class IndicatorViewModel: ObservableObject {
                 // Flush the trailing <30s window off the main actor. stop() blocks on the
                 // engine's serial queue, so it waits for the previous recording's finalize
                 // -> ordered transcription + ordered insertion.
-                let text = await Task.detached { [streamingEngine = self.streamingEngine] in
+                let result = await Task.detached { [streamingEngine = self.streamingEngine] in
                     streamingEngine.stop()
                 }.value
-                await self.persist(text: text, tempURL: tempURL)
+
+                switch result {
+                case .transcribed(let text):
+                    await self.persist(text: text, tempURL: tempURL)
+                case .unavailable:
+                    // Streaming never ran (no model / mic / start error): fall back to the
+                    // file-based pass so the recording is never lost.
+                    await self.transcribeFileFallback(tempURL: tempURL)
+                }
                 self.delegate?.didFinishDecoding(for: self)
             }
             return
@@ -228,6 +236,20 @@ class IndicatorViewModel: ObservableObject {
         }
     }
     
+    /// Fallback when live streaming could not run: transcribe the recorded WAV with the
+    /// regular file-based engine so the recording is never lost.
+    private func transcribeFileFallback(tempURL: URL?) async {
+        guard let tempURL = tempURL else { return }
+        do {
+            print("Live streaming unavailable - falling back to file transcription")
+            let text = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
+            await persist(text: text, tempURL: tempURL)
+        } catch {
+            print("Fallback transcription failed: \(error)")
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+    }
+
     /// Saves the transcription (moving the recorded WAV to its final location when present)
     /// and inserts/copies the text. Used by the live streaming path.
     private func persist(text: String, tempURL: URL?) async {

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -155,6 +155,7 @@ class IndicatorViewModel: ObservableObject {
 
                 switch result {
                 case .transcribed(let text):
+                    print("Live transcription result: \(text)")
                     await self.persist(text: text, tempURL: tempURL)
                 case .unavailable:
                     // Streaming never ran (no model / mic / start error): fall back to the

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -100,7 +100,14 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         }
     }
     
-    func didFinishDecoding() {
-        hide()
+    func didFinishDecoding(for vm: IndicatorViewModel) {
+        // Only hide when the CURRENT session finishes. If a newer recording has already
+        // taken over the indicator (overshadow), a stale session finishing in the
+        // background must not hide it — just clean the stale one up.
+        if viewModel === vm {
+            hide()
+        } else {
+            vm.cleanup()
+        }
     }
 }

--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -234,7 +234,7 @@ class OnboardingViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = unifiedModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -91,7 +91,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private var languageSubmenu: NSMenu?
     private var microphoneService = MicrophoneService.shared
     private var microphoneObserver: AnyCancellable?
-    
+    private var isTerminating = false
+
     func applicationDidFinishLaunching(_ notification: Notification) {
 
         setupStatusBarItem()
@@ -106,6 +107,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         OpenSuperWhisperApp.startTranscriptionQueue()
         observeMicrophoneChanges()
+    }
+
+    /// Graceful quit: first let any in-flight transcription finish, then release the live
+    /// and file whisper contexts. Freeing them runs `whisper_free`, which frees the model's
+    /// Metal buffers and drains their macOS 15+ residency sets *before* the GPU device is
+    /// torn down — the app-side root-cause fix for the quit-time abort (libwhisper also
+    /// carries a defensive fix). Singletons are never deinit'd at process exit, so this has
+    /// to be done explicitly here.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if isTerminating {
+            return .terminateNow
+        }
+        isTerminating = true
+
+        Task { @MainActor in
+            await TranscriptionQueue.shared.waitUntilIdle()
+            await StreamingWhisperEngine.shared.shutdown()
+            TranscriptionService.shared.releaseEngine()
+            NSApplication.shared.reply(toApplicationShouldTerminate: true)
+        }
+
+        return .terminateLater
     }
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -48,6 +48,11 @@ struct OpenSuperWhisperApp: App {
     }
 
     init() {
+        // Line-buffer stdout so log output (Swift `print`) is flushed per line when stdout is
+        // redirected to a file (e.g. `open --stdout ...`). Otherwise stdout is block-buffered and
+        // withholds output until the buffer fills — and an abort() on quit never flushes it — which
+        // makes live/long logs look stalled or truncated even though transcription is fine.
+        setvbuf(stdout, nil, _IOLBF, 0)
         _ = ShortcutManager.shared
         _ = MicrophoneService.shared
         WhisperModelManager.shared.ensureDefaultModelPresent()

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -110,6 +110,12 @@ class SettingsViewModel: ObservableObject {
             AppPreferences.shared.debugMode = debugMode
         }
     }
+
+    @Published var liveStreamingEnabled: Bool {
+        didSet {
+            AppPreferences.shared.liveStreamingEnabled = liveStreamingEnabled
+        }
+    }
     
     @Published var playSoundOnRecordStart: Bool {
         didSet {
@@ -168,6 +174,7 @@ class SettingsViewModel: ObservableObject {
         self.useBeamSearch = prefs.useBeamSearch
         self.beamSize = prefs.beamSize
         self.debugMode = prefs.debugMode
+        self.liveStreamingEnabled = prefs.liveStreamingEnabled
         self.playSoundOnRecordStart = prefs.playSoundOnRecordStart
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
@@ -887,6 +894,21 @@ struct SettingsView: View {
                             Toggle("", isOn: $viewModel.addSpaceAfterSentence)
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
                                 .labelsHidden()
+                        }
+
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Live Streaming (Whisper)")
+                                    .font(.subheadline)
+                                Text("Transcribe while recording for a near-instant result on stop")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $viewModel.liveStreamingEnabled)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                                .disabled(viewModel.selectedEngine != "whisper")
                         }
                     }
                 }

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -373,7 +373,7 @@ class SettingsViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = downloadableFluidAudioModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/TranscriptionQueue.swift
+++ b/OpenSuperWhisper/TranscriptionQueue.swift
@@ -71,6 +71,14 @@ class TranscriptionQueue: ObservableObject {
         }
     }
 
+    /// Awaits until the queue has drained every pending recording. Used for a graceful
+    /// shutdown so in-flight transcriptions finish instead of being interrupted.
+    func waitUntilIdle() async {
+        while let task = processingTask {
+            await task.value
+        }
+    }
+
     private func cleanupMissingFiles() async {
         let pendingRecordings = recordingStore.getPendingRecordings()
 

--- a/OpenSuperWhisper/TranscriptionService.swift
+++ b/OpenSuperWhisper/TranscriptionService.swift
@@ -27,11 +27,18 @@ class TranscriptionService: ObservableObject {
         currentEngine?.cancelTranscription()
         transcriptionTask?.cancel()
         transcriptionTask = nil
-        
+
         isTranscribing = false
         currentSegment = ""
         progress = 0.0
         isCancelled = false
+    }
+
+    /// Releases the active engine so its whisper context (if any) is deallocated — and thus
+    /// `whisper_free`'d — which frees the model's Metal buffers and drains their macOS 15+
+    /// residency sets. Call only when no transcription is in flight (e.g. on app quit).
+    func releaseEngine() {
+        currentEngine = nil
     }
     
     private func loadEngine() {

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -89,6 +89,10 @@ final class AppPreferences {
     
     @UserDefault(key: "debugMode", defaultValue: false)
     var debugMode: Bool
+
+    // Live (resumable) streaming transcription while recording. Whisper engine only.
+    @UserDefault(key: "liveStreamingEnabled", defaultValue: false)
+    var liveStreamingEnabled: Bool
     
     @UserDefault(key: "playSoundOnRecordStart", defaultValue: false)
     var playSoundOnRecordStart: Bool

--- a/OpenSuperWhisper/Whis/Whis.swift
+++ b/OpenSuperWhisper/Whis/Whis.swift
@@ -651,6 +651,72 @@ public class MyWhisperContext {
         return result == 0
     }
     
+    // MARK: - Resumable / Streaming
+    //
+    // Drives whisper's own seek loop incrementally so transcription can run while
+    // audio is still being captured. With mel_norm_mode == GLOBAL the output is
+    // identical to a single whisper_full() pass over the concatenated audio.
+    //
+    //     ctx.resumableReset()
+    //     while recording {
+    //         ctx.appendAudio(samples: pcm)                       // 16 kHz mono f32
+    //         let nNew = ctx.fullResumable(params: &p, finalize: false)
+    //         // ... read the nNew newly produced segments ...
+    //     }
+    //     _ = ctx.fullResumable(params: &p, finalize: true)       // flush the tail
+
+    /// Clears accumulated audio, seek, context and results. Call before a new stream.
+    public func resumableReset() {
+        guard let ctx = ctx else { return }
+        if let state = state {
+            whisper_resumable_reset_with_state(ctx, state)
+        } else {
+            whisper_resumable_reset(ctx)
+        }
+    }
+
+    /// Append PCM (16 kHz, mono, f32). The mel spectrogram is computed incrementally;
+    /// the raw samples are not retained. Returns true on success.
+    public func appendAudio(samples: [Float]) -> Bool {
+        guard let ctx = ctx else { return false }
+        let result = samples.withUnsafeBufferPointer { buffer -> Int32 in
+            if let state = state {
+                return whisper_append_audio_with_state(ctx, state, buffer.baseAddress, Int32(samples.count))
+            }
+            return whisper_append_audio(ctx, buffer.baseAddress, Int32(samples.count))
+        }
+        return result == 0
+    }
+
+    /// Decode complete 30s windows from the accumulated audio.
+    /// Returns the number of NEW segments (>= 0), or < 0 on error. When finalize is
+    /// false and less than 30s of undecoded audio is available, returns 0 ("need more").
+    public func fullResumable(params: inout whisper_full_params, finalize: Bool) -> Int {
+        guard let ctx = ctx else { return -1 }
+        let result: Int32
+        if let state = state {
+            result = whisper_full_resumable_with_state(ctx, state, params, finalize)
+        } else {
+            result = whisper_full_resumable(ctx, params, finalize)
+        }
+
+        // Free c-allocated strings duplicated by WhisperFullParams.toC(), as full() does.
+        if let suppressRegex = params.suppress_regex {
+            free(UnsafeMutablePointer(mutating: suppressRegex))
+        }
+        if let initialPrompt = params.initial_prompt {
+            free(UnsafeMutablePointer(mutating: initialPrompt))
+        }
+        if let language = params.language {
+            free(UnsafeMutablePointer(mutating: language))
+        }
+        if let baseAddress = params.grammar_rules {
+            free(UnsafeMutableRawPointer(mutating: baseAddress))
+        }
+
+        return Int(result)
+    }
+
     public func fullParallel(samples: [Float], params: inout WhisperFullParams, nProcessors: Int) -> Bool {
         guard let ctx = ctx else { return false }
         let cParams = params.toC()

--- a/OpenSuperWhisper/Whis/WhisperFullParams.swift
+++ b/OpenSuperWhisper/Whis/WhisperFullParams.swift
@@ -59,6 +59,12 @@ public struct WhisperFullParams {
     public var iStartRule: Int = 0
     public var grammarPenalty: Float = 0.0
 
+    // Log-mel normalization (used by the resumable/streaming API; ignored by whisper_full).
+    // 0 = WHISPER_MEL_NORM_GLOBAL (batch-identical, default), 1 = WHISPER_MEL_NORM_WINDOW.
+    public var melNormMode: Int32 = 0
+    public var melNormHalfLife: Float = 0.0
+    public var melNormMaxDrop: Float = 0.0
+
     public init() {}
 
     mutating func toC() -> whisper_full_params {
@@ -158,6 +164,10 @@ public struct WhisperFullParams {
 
         cParams.i_start_rule = Int(iStartRule)
         cParams.grammar_penalty = grammarPenalty
+
+        cParams.mel_norm_mode = melNormMode
+        cParams.mel_norm_half_life = melNormHalfLife
+        cParams.mel_norm_max_drop = melNormMaxDrop
 
         return cParams
     }


### PR DESCRIPTION
## What

Live, "pipelined" transcription: audio is transcribed *while* recording via whisper's resumable API, so when you stop only the trailing <30s window remains to decode (near-instant), at full large-model quality.

- New `StreamingWhisperEngine`: own `AVAudioEngine` tap → 16k mono → serial whisper queue driving `whisper_append_audio` + `whisper_full_resumable`.
- Runs in parallel with the existing WAV recorder (playback / re-transcribe stay intact); falls back to a file pass if streaming can't run.
- Opt-in via a new "Live Streaming (Whisper)" preference (whisper engine only). Both the menubar hotkey and the in-app record button use it; re-transcribing existing recordings stays file-based.

## whisper.cpp dependency — works today via my fork

This uses a resumable streaming API I added to whisper.cpp, submitted upstream as ggml-org/whisper.cpp#3869. **In the meantime it works as-is**: the `libwhisper/whisper.cpp` submodule points at my fork (`AlexCherrypi/whisper.cpp`, branch `master`), which already has the API, so this branch builds and runs right now. Once #3869 lands upstream, the submodule can simply be repointed to the canonical repo — no code changes needed.

## Also included

- **FluidAudio 0.11.0 → 0.15.2** — required to build under Xcode 26.5 (0.11 fails Swift 6 `sending` checks); includes the small `AsrManager.loadModels` / `transcribe(_:decoderState:)` API migration.
- stdout line-buffering at launch so logs flush reliably.
- **Clean shutdown:** on quit the app now waits for any in-flight transcription to finish, then frees the whisper contexts (`applicationShouldTerminate` → release the live + file engines). That runs `whisper_free`, which releases the Metal backend's buffers and drains their macOS 15+ residency sets *before* the GPU device is torn down — avoiding an abort-on-quit. Complements the ggml-metal fix submitted upstream as ggml-org/whisper.cpp#3870 and ggml-org/llama.cpp#24368, so OSW shuts down cleanly even against an unpatched ggml.

Happy to adjust — feedback welcome.
