### PR TITLE
Add retention policy for recordings + Launch at Login

### DIFF
--- a/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "5d9176eb35bcbe009c7b26202f0e92c85ff2dedf",
-        "version" : "0.11.0"
+        "revision" : "7f963cdc43ba89c5993654f1e138047d517a818d",
+        "version" : "0.15.2"
       }
     },
     {

--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -29,6 +29,9 @@ class ContentViewModel: ObservableObject {
     private var currentPage = 0
     private let pageSize = 100
     private var currentSearchQuery = ""
+    /// Bumped on every full reload so an in-flight load started before a reload
+    /// (e.g. just before a retention prune) discards its now-stale results.
+    private var loadGeneration = 0
     private var blinkTimer: Timer?
     private var recordingStartTime: Date?
     private var durationTimer: Timer?
@@ -67,10 +70,20 @@ class ContentViewModel: ObservableObject {
     }
     
     func loadInitialData() {
-        currentSearchQuery = ""
+        startFreshLoad(query: "")
+    }
+
+    /// Resets paging and starts a fresh page-0 load. Bumps the load generation so
+    /// any in-flight load discards its stale results instead of overwriting the
+    /// list, and clears `isLoadingMore` so the reload is never dropped by the
+    /// in-flight guard.
+    private func startFreshLoad(query: String) {
+        currentSearchQuery = query
         currentPage = 0
         canLoadMore = true
         recordings = []
+        loadGeneration += 1
+        isLoadingMore = false
         loadMore()
     }
 
@@ -79,6 +92,7 @@ class ContentViewModel: ObservableObject {
         isLoadingMore = true
         
         // Capture current state for async task
+        let generation = loadGeneration
         let page = currentPage
         let limit = pageSize
         let query = currentSearchQuery
@@ -95,15 +109,12 @@ class ContentViewModel: ObservableObject {
             
             
             await MainActor.run {
-                defer {
-                    self.isLoadingMore = false
-                }
-                
-                // Ensure we are still consistent with the request (basic check)
-                guard self.currentSearchQuery == query else { 
-                    return 
-                }
-                
+                // Discard results once a newer reload (e.g. after a retention
+                // prune) has superseded this load, so stale rows never overwrite
+                // the freshly reloaded list.
+                guard generation == self.loadGeneration else { return }
+                self.isLoadingMore = false
+
                 if page == 0 {
                     self.recordings = newRecordings
                 } else {
@@ -120,11 +131,7 @@ class ContentViewModel: ObservableObject {
     }
     
     func search(query: String) {
-        currentSearchQuery = query
-        currentPage = 0
-        canLoadMore = true
-        recordings = []
-        loadMore()
+        startFreshLoad(query: query)
     }
     
     func handleProgressUpdate(id: UUID, transcription: String?, progress: Float, status: RecordingStatus, isRegeneration: Bool?) {

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -23,8 +23,8 @@ class FluidAudioEngine: TranscriptionEngine {
         
         let models = try await AsrModels.downloadAndLoad(version: version)
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
-        
+        try await manager.loadModels(models)
+
         asrManager = manager
         asrModels = models
     }
@@ -73,8 +73,11 @@ class FluidAudioEngine: TranscriptionEngine {
             progressTask = nil
         }
         
-        // Perform actual transcription - FluidAudio will emit progress automatically
-        let result = try await asrManager.transcribe(url)
+        // Perform actual transcription - FluidAudio will emit progress automatically.
+        // FluidAudio 0.15.x requires an explicit decoder state; a fresh one per call is
+        // correct for one-shot file transcription (no cross-call streaming continuity).
+        var decoderState = try TdtDecoderState()
+        let result = try await asrManager.transcribe(url, decoderState: &decoderState)
         
         guard !isCancelled else {
             throw CancellationError()

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -373,6 +373,83 @@ class RecordingStore: ObservableObject {
         }
     }
 
+    // MARK: - Retention policy
+
+    /// Applies the user's retention policy, deleting recordings that exceed the
+    /// configured maximum count and/or that are older than the configured age.
+    /// In-progress recordings (pending / converting / transcribing) are never
+    /// removed. Returns the number of recordings that were deleted.
+    @discardableResult
+    func enforceRetentionPolicy() async -> Int {
+        let policy = RetentionPolicy()
+        guard policy.isActive else { return 0 }
+
+        let deleted: [Recording]
+        do {
+            deleted = try await deleteExpiredRecordings(policy: policy)
+        } catch {
+            print("Failed to enforce retention policy: \(error)")
+            return 0
+        }
+
+        guard !deleted.isEmpty else { return 0 }
+
+        // Remove the stored audio files off the main actor.
+        await Task.detached(priority: .utility) {
+            for recording in deleted {
+                try? FileManager.default.removeItem(at: recording.url)
+            }
+        }.value
+
+        let deletedIds = Set(deleted.map { $0.id })
+        recordings.removeAll { deletedIds.contains($0.id) }
+
+        NotificationCenter.default.post(name: Self.recordingsDidUpdateNotification, object: nil)
+        return deleted.count
+    }
+
+    private nonisolated func deleteExpiredRecordings(policy: RetentionPolicy) async throws -> [Recording] {
+        try await dbQueue.write { db in
+            let activeStatuses = [
+                RecordingStatus.pending.rawValue,
+                RecordingStatus.converting.rawValue,
+                RecordingStatus.transcribing.rawValue
+            ]
+
+            var toDelete: [UUID: Recording] = [:]
+
+            // Age-based expiration: anything older than the cutoff date.
+            if let cutoff = policy.ageCutoffDate() {
+                let expired = try Recording
+                    .filter(!activeStatuses.contains(Recording.Columns.status))
+                    .filter(Recording.Columns.timestamp < cutoff)
+                    .fetchAll(db)
+                for recording in expired {
+                    toDelete[recording.id] = recording
+                }
+            }
+
+            // Count-based expiration: keep the newest `maxCount`, drop the rest.
+            if policy.maxCountEnabled, policy.maxCount > 0 {
+                let finished = try Recording
+                    .filter(!activeStatuses.contains(Recording.Columns.status))
+                    .order(Recording.Columns.timestamp.desc)
+                    .fetchAll(db)
+                if finished.count > policy.maxCount {
+                    for recording in finished[policy.maxCount...] {
+                        toDelete[recording.id] = recording
+                    }
+                }
+            }
+
+            for recording in toDelete.values {
+                _ = try recording.delete(db)
+            }
+
+            return Array(toDelete.values)
+        }
+    }
+
     func searchRecordings(query: String) -> [Recording] {
         do {
             return try dbQueue.read { db in

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -187,6 +187,10 @@ class RecordingStore: ObservableObject {
                 await MainActor.run {
                     NotificationCenter.default.post(name: Self.recordingsDidUpdateNotification, object: nil)
                 }
+                // Keep the store within the retention limit right after a new
+                // recording lands, so the count behaves like a fixed-size buffer
+                // instead of overshooting until the next periodic check.
+                await enforceRetentionPolicy()
             } catch {
                 print("Failed to add recording: \(error)")
             }

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -74,6 +74,7 @@ class RecordingStore: ObservableObject {
 
     @Published private(set) var recordings: [Recording] = []
     private let dbQueue: DatabaseQueue
+    private var retentionTimer: Timer?
 
     private init() {
         let applicationSupport = FileManager.default.urls(
@@ -406,6 +407,31 @@ class RecordingStore: ObservableObject {
 
         NotificationCenter.default.post(name: Self.recordingsDidUpdateNotification, object: nil)
         return deleted.count
+    }
+
+    /// Interval between periodic age-based retention checks.
+    private static let retentionCheckInterval: TimeInterval = 60
+
+    /// Starts a periodic timer that re-applies the retention policy.
+    ///
+    /// This is needed for the age-based limit: recordings expire as real time
+    /// passes, even when no new recordings are added. The count-based limit does
+    /// not need this — it is enforced whenever recordings are added (when the
+    /// transcription queue drains). The periodic check therefore only does work
+    /// while the age policy is enabled.
+    func startRetentionScheduler() {
+        // Run once immediately so expired recordings are cleaned up on launch.
+        Task { await enforceRetentionPolicy() }
+
+        retentionTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: Self.retentionCheckInterval, repeats: true) { _ in
+            Task { @MainActor in
+                guard AppPreferences.shared.retentionMaxAgeEnabled else { return }
+                await RecordingStore.shared.enforceRetentionPolicy()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        retentionTimer = timer
     }
 
     private nonisolated func deleteExpiredRecordings(policy: RetentionPolicy) async throws -> [Recording] {

--- a/OpenSuperWhisper/Models/RetentionPolicy.swift
+++ b/OpenSuperWhisper/Models/RetentionPolicy.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Time unit used by the age-based retention policy.
+enum RetentionUnit: String, CaseIterable, Identifiable {
+    case minutes
+    case hours
+    case days
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .minutes: return "Minutes"
+        case .hours: return "Hours"
+        case .days: return "Days"
+        }
+    }
+
+    /// Number of seconds in a single unit.
+    var seconds: TimeInterval {
+        switch self {
+        case .minutes: return 60
+        case .hours: return 60 * 60
+        case .days: return 60 * 60 * 24
+        }
+    }
+}
+
+/// Snapshot of the user's retention preferences.
+///
+/// Two independent switches can be active at the same time:
+/// - a maximum number of recordings / transcriptions to keep, and
+/// - a maximum age, after which recordings are deleted.
+struct RetentionPolicy {
+    var maxCountEnabled: Bool
+    var maxCount: Int
+    var maxAgeEnabled: Bool
+    var maxAgeValue: Int
+    var maxAgeUnit: RetentionUnit
+
+    init(from prefs: AppPreferences = .shared) {
+        self.maxCountEnabled = prefs.retentionMaxCountEnabled
+        self.maxCount = prefs.retentionMaxCount
+        self.maxAgeEnabled = prefs.retentionMaxAgeEnabled
+        self.maxAgeValue = prefs.retentionMaxAgeValue
+        self.maxAgeUnit = RetentionUnit(rawValue: prefs.retentionMaxAgeUnit) ?? .days
+    }
+
+    /// Whether at least one retention switch is active and meaningful.
+    var isActive: Bool {
+        (maxCountEnabled && maxCount > 0) || (maxAgeEnabled && maxAgeValue > 0)
+    }
+
+    /// Cutoff date for the age policy. Recordings with a timestamp strictly
+    /// before this date are considered expired. `nil` when the age policy is off.
+    func ageCutoffDate(now: Date = Date()) -> Date? {
+        guard maxAgeEnabled, maxAgeValue > 0 else { return nil }
+        let interval = Double(maxAgeValue) * maxAgeUnit.seconds
+        return now.addingTimeInterval(-interval)
+    }
+}

--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -234,7 +234,7 @@ class OnboardingViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = unifiedModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -60,6 +60,12 @@ extension OpenSuperWhisperApp {
             TranscriptionQueue.shared.startProcessingQueue()
         }
     }
+
+    static func startRetentionScheduler() {
+        Task { @MainActor in
+            RecordingStore.shared.startRetentionScheduler()
+        }
+    }
 }
 
 class AppState: ObservableObject {
@@ -100,6 +106,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         }
 
         OpenSuperWhisperApp.startTranscriptionQueue()
+        OpenSuperWhisperApp.startRetentionScheduler()
         observeMicrophoneChanges()
     }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -584,6 +584,7 @@ struct Settings {
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
+    @ObservedObject private var launchAtLogin = LaunchAtLoginManager.shared
     @Environment(\.dismiss) var dismiss
     @State private var isRecordingNewShortcut = false
     @State private var selectedTab = 0
@@ -660,6 +661,7 @@ struct SettingsView: View {
         }
         .onAppear {
             previousModelURL = viewModel.selectedModelURL
+            launchAtLogin.refresh()
             if viewModel.selectedEngine == "fluidaudio" {
                 viewModel.initializeFluidAudioModels()
             }
@@ -1157,6 +1159,34 @@ struct SettingsView: View {
     private var advancedSettings: some View {
         Form {
             VStack(spacing: 20) {
+                // Startup
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Startup")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Launch at Login")
+                                .font(.subheadline)
+                            Text("Automatically start OpenSuperWhisper when you log in")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { launchAtLogin.isEnabled },
+                            set: { launchAtLogin.setEnabled($0) }
+                        ))
+                        .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                        .labelsHidden()
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
                 // Decoding Strategy
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Decoding Strategy")

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -154,6 +154,51 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Retention / storage policy
+
+    @Published var retentionMaxCountEnabled: Bool {
+        didSet {
+            AppPreferences.shared.retentionMaxCountEnabled = retentionMaxCountEnabled
+            enforceRetention()
+        }
+    }
+
+    @Published var retentionMaxCount: Int {
+        didSet {
+            AppPreferences.shared.retentionMaxCount = max(1, retentionMaxCount)
+            enforceRetention()
+        }
+    }
+
+    @Published var retentionMaxAgeEnabled: Bool {
+        didSet {
+            AppPreferences.shared.retentionMaxAgeEnabled = retentionMaxAgeEnabled
+            enforceRetention()
+        }
+    }
+
+    @Published var retentionMaxAgeValue: Int {
+        didSet {
+            AppPreferences.shared.retentionMaxAgeValue = max(1, retentionMaxAgeValue)
+            enforceRetention()
+        }
+    }
+
+    @Published var retentionMaxAgeUnit: RetentionUnit {
+        didSet {
+            AppPreferences.shared.retentionMaxAgeUnit = retentionMaxAgeUnit.rawValue
+            enforceRetention()
+        }
+    }
+
+    /// Applies the retention policy immediately so the user sees the effect of
+    /// toggling a switch or changing a limit without waiting for the next recording.
+    private func enforceRetention() {
+        Task { @MainActor in
+            await RecordingStore.shared.enforceRetentionPolicy()
+        }
+    }
+
     init() {
         let prefs = AppPreferences.shared
         self.selectedEngine = prefs.selectedEngine
@@ -175,6 +220,11 @@ class SettingsViewModel: ObservableObject {
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
         self.autoCopyToClipboard = prefs.autoCopyToClipboard
         self.autoPasteTranscription = prefs.autoPasteTranscription
+        self.retentionMaxCountEnabled = prefs.retentionMaxCountEnabled
+        self.retentionMaxCount = prefs.retentionMaxCount
+        self.retentionMaxAgeEnabled = prefs.retentionMaxAgeEnabled
+        self.retentionMaxAgeValue = prefs.retentionMaxAgeValue
+        self.retentionMaxAgeUnit = RetentionUnit(rawValue: prefs.retentionMaxAgeUnit) ?? .days
 
         if let savedPath = prefs.selectedWhisperModelPath ?? prefs.selectedModelPath {
             self.selectedModelURL = URL(fileURLWithPath: savedPath)
@@ -561,13 +611,20 @@ struct SettingsView: View {
                     Label("Transcription", systemImage: "text.bubble")
                 }
                 .tag(2)
-            
+
+            // Storage / Retention Settings
+            storageSettings
+                .tabItem {
+                    Label("Storage", systemImage: "externaldrive")
+                }
+                .tag(3)
+
             // Advanced Settings
             advancedSettings
                 .tabItem {
                     Label("Advanced", systemImage: "gear")
                 }
-                .tag(3)
+                .tag(4)
             }
         .padding()
         .frame(width: 550)
@@ -1003,6 +1060,100 @@ struct SettingsView: View {
         }
     }
     
+    private var storageSettings: some View {
+        Form {
+            VStack(spacing: 20) {
+                // Maximum number of recordings
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Limit Number of Recordings")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            Text("Keep only the most recent recordings & transcriptions")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: $viewModel.retentionMaxCountEnabled)
+                            .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                            .labelsHidden()
+                    }
+
+                    if viewModel.retentionMaxCountEnabled {
+                        HStack {
+                            Text("Keep at most")
+                                .font(.subheadline)
+                            Spacer()
+                            TextField("", value: $viewModel.retentionMaxCount, format: .number)
+                                .textFieldStyle(.roundedBorder)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 80)
+                            Stepper("", value: $viewModel.retentionMaxCount, in: 1...100000)
+                                .labelsHidden()
+                            Text("recordings")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
+                // Maximum age
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Delete Old Recordings")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            Text("Automatically remove recordings older than the chosen age")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: $viewModel.retentionMaxAgeEnabled)
+                            .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                            .labelsHidden()
+                    }
+
+                    if viewModel.retentionMaxAgeEnabled {
+                        HStack {
+                            Text("Delete after")
+                                .font(.subheadline)
+                            Spacer()
+                            TextField("", value: $viewModel.retentionMaxAgeValue, format: .number)
+                                .textFieldStyle(.roundedBorder)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 70)
+                            Stepper("", value: $viewModel.retentionMaxAgeValue, in: 1...100000)
+                                .labelsHidden()
+                            Picker("", selection: $viewModel.retentionMaxAgeUnit) {
+                                ForEach(RetentionUnit.allCases) { unit in
+                                    Text(unit.displayName).tag(unit)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(width: 110)
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
+                Text("Both limits can be active at the same time. Cleanup runs automatically when you change these settings and after each new transcription. Recordings that are still being processed are never deleted.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding()
+        }
+    }
+
     private var advancedSettings: some View {
         Form {
             VStack(spacing: 20) {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -165,7 +165,15 @@ class SettingsViewModel: ObservableObject {
 
     @Published var retentionMaxCount: Int {
         didSet {
-            AppPreferences.shared.retentionMaxCount = max(1, retentionMaxCount)
+            // Clamp the published property itself (not only the stored value) so the UI and
+            // the persisted/enforced value can never diverge. The re-assignment re-enters
+            // didSet once with an already-clamped value, which then falls through.
+            let clamped = max(1, retentionMaxCount)
+            if clamped != retentionMaxCount {
+                retentionMaxCount = clamped
+                return
+            }
+            AppPreferences.shared.retentionMaxCount = clamped
             enforceRetention()
         }
     }
@@ -179,7 +187,14 @@ class SettingsViewModel: ObservableObject {
 
     @Published var retentionMaxAgeValue: Int {
         didSet {
-            AppPreferences.shared.retentionMaxAgeValue = max(1, retentionMaxAgeValue)
+            // Clamp the published property itself (see retentionMaxCount) so the UI and the
+            // persisted/enforced value can never diverge.
+            let clamped = max(1, retentionMaxAgeValue)
+            if clamped != retentionMaxAgeValue {
+                retentionMaxAgeValue = clamped
+                return
+            }
+            AppPreferences.shared.retentionMaxAgeValue = clamped
             enforceRetention()
         }
     }
@@ -191,11 +206,20 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
-    /// Applies the retention policy immediately so the user sees the effect of
-    /// toggling a switch or changing a limit without waiting for the next recording.
+    private var retentionEnforceTimer: Timer?
+
+    /// Applies the retention policy after a short debounce so the user sees the effect of
+    /// toggling a switch or changing a limit, without the data-loss footgun of enforcing on
+    /// every keystroke: the count/age TextFields use `format: .number`, whose binding commits
+    /// (and fires didSet) on each parsed value, so typing "500" passes through 5 and 50.
+    /// Enforcing immediately would permanently delete recordings at those intermediate values.
+    /// Debouncing coalesces a burst of edits into a single enforcement at the final value.
     private func enforceRetention() {
-        Task { @MainActor in
-            await RecordingStore.shared.enforceRetentionPolicy()
+        retentionEnforceTimer?.invalidate()
+        retentionEnforceTimer = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: false) { _ in
+            Task { @MainActor in
+                await RecordingStore.shared.enforceRetentionPolicy()
+            }
         }
     }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1145,7 +1145,7 @@ struct SettingsView: View {
                 .background(Color(.controlBackgroundColor).opacity(0.3))
                 .cornerRadius(12)
 
-                Text("Both limits can be active at the same time. Cleanup runs automatically when you change these settings and after each new transcription. Recordings that are still being processed are never deleted.")
+                Text("Both limits can be active at the same time. Cleanup runs automatically when you change these settings and after each new transcription, and the age limit is also re-checked periodically in the background. Recordings that are still being processed are never deleted.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -440,7 +440,7 @@ class SettingsViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = downloadableFluidAudioModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/TranscriptionQueue.swift
+++ b/OpenSuperWhisper/TranscriptionQueue.swift
@@ -66,6 +66,7 @@ class TranscriptionQueue: ObservableObject {
         processingTask = Task {
             await cleanupMissingFiles()
             await processQueue()
+            await recordingStore.enforceRetentionPolicy()
             isProcessing = false
             processingTask = nil
         }

--- a/OpenSuperWhisper/TranscriptionQueue.swift
+++ b/OpenSuperWhisper/TranscriptionQueue.swift
@@ -66,7 +66,6 @@ class TranscriptionQueue: ObservableObject {
         processingTask = Task {
             await cleanupMissingFiles()
             await processQueue()
-            await recordingStore.enforceRetentionPolicy()
             isProcessing = false
             processingTask = nil
         }
@@ -171,6 +170,10 @@ class TranscriptionQueue: ObservableObject {
             currentRecordingId = recording.id
             await processRecording(recording)
             currentRecordingId = nil
+            // Enforce the retention limit after each recording finishes so the
+            // count is held as a fixed-size buffer. In-progress recordings stay
+            // excluded; they get pruned as soon as they finish on a later pass.
+            await recordingStore.enforceRetentionPolicy()
         }
     }
 

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -117,4 +117,23 @@ final class AppPreferences {
 
     @UserDefault(key: "autoPasteTranscription", defaultValue: true)
     var autoPasteTranscription: Bool
+
+    // Retention / storage policy
+    // Limit the number of stored recordings & transcriptions.
+    @UserDefault(key: "retentionMaxCountEnabled", defaultValue: false)
+    var retentionMaxCountEnabled: Bool
+
+    @UserDefault(key: "retentionMaxCount", defaultValue: 100)
+    var retentionMaxCount: Int
+
+    // Delete recordings & transcriptions older than a given age.
+    @UserDefault(key: "retentionMaxAgeEnabled", defaultValue: false)
+    var retentionMaxAgeEnabled: Bool
+
+    @UserDefault(key: "retentionMaxAgeValue", defaultValue: 30)
+    var retentionMaxAgeValue: Int
+
+    // One of RetentionUnit.rawValue: "minutes" | "hours" | "days"
+    @UserDefault(key: "retentionMaxAgeUnit", defaultValue: "days")
+    var retentionMaxAgeUnit: String
 }

--- a/OpenSuperWhisper/Utils/LaunchAtLoginManager.swift
+++ b/OpenSuperWhisper/Utils/LaunchAtLoginManager.swift
@@ -1,0 +1,43 @@
+import Foundation
+import ServiceManagement
+
+/// Manages whether the app launches automatically when the user logs in.
+///
+/// Uses `SMAppService.mainApp` (macOS 13+), which registers the main app
+/// itself as a login item — no separate helper bundle required. The published
+/// `isEnabled` always reflects the real, system-reported registration state.
+@MainActor
+final class LaunchAtLoginManager: ObservableObject {
+    static let shared = LaunchAtLoginManager()
+
+    @Published private(set) var isEnabled: Bool
+
+    private init() {
+        self.isEnabled = SMAppService.mainApp.status == .enabled
+    }
+
+    /// Re-reads the current state from the system. Call this when the settings
+    /// window appears, in case the user changed the login item elsewhere.
+    func refresh() {
+        isEnabled = SMAppService.mainApp.status == .enabled
+    }
+
+    /// Enables or disables launch-at-login, then syncs `isEnabled` to the
+    /// resulting system state so the UI reflects what actually happened.
+    func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                if SMAppService.mainApp.status != .enabled {
+                    try SMAppService.mainApp.register()
+                }
+            } else {
+                if SMAppService.mainApp.status == .enabled {
+                    try SMAppService.mainApp.unregister()
+                }
+            }
+        } catch {
+            print("Failed to update Launch at Login: \(error)")
+        }
+        isEnabled = SMAppService.mainApp.status == .enabled
+    }
+}


### PR DESCRIPTION
## What

Adds an optional **retention policy** for stored recordings/transcriptions, in a new **Storage** settings tab, plus a **Launch at Login** toggle.

- **Limit Number of Recordings** — keep only the newest *N* recordings & transcriptions.
- **Delete Old Recordings** — remove anything older than a configurable age (minutes / hours / days).
- Both switches are independent and can be active at the same time. **Off by default** (defaults: keep 100 / 30 days).
- **Launch at Login** toggle (Advanced tab) using `SMAppService.mainApp` (macOS 13+, no helper bundle).

## Safety / behavior

- In-progress recordings (`pending` / `converting` / `transcribing`) are **never** deleted.
- Enforcement runs on launch, after each transcription (queue drain), on a 60 s background timer (age limit only), and after a settings change.
- Settings edits are **debounced (0.6 s)** and the count/age inputs are **clamped to ≥ 1**, so typing an intermediate value (e.g. passing through `5` while typing `500` into a `.number` field) can't trigger a premature delete.
- Audio files are removed only **after** the database row is deleted.

## Also included

- **FluidAudio 0.11.0 → 0.15.2** — needed to build under Xcode 26.5 (0.11 fails Swift 6 `sending` checks). This bump is shared across my feature PRs; happy to drop it (or the Launch-at-Login part) if you'd prefer a tighter scope.

Happy to adjust — feedback welcome.
