### PR TITLE
Add custom dictionary / keyword boosting (#19)

### DIFF
--- a/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "5d9176eb35bcbe009c7b26202f0e92c85ff2dedf",
-        "version" : "0.11.0"
+        "revision" : "7f963cdc43ba89c5993654f1e138047d517a818d",
+        "version" : "0.15.2"
       }
     },
     {

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -23,8 +23,8 @@ class FluidAudioEngine: TranscriptionEngine {
         
         let models = try await AsrModels.downloadAndLoad(version: version)
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
-        
+        try await manager.loadModels(models)
+
         asrManager = manager
         asrModels = models
     }
@@ -73,8 +73,11 @@ class FluidAudioEngine: TranscriptionEngine {
             progressTask = nil
         }
         
-        // Perform actual transcription - FluidAudio will emit progress automatically
-        let result = try await asrManager.transcribe(url)
+        // Perform actual transcription - FluidAudio will emit progress automatically.
+        // FluidAudio 0.15.x requires an explicit decoder state; a fresh one per call is
+        // correct for one-shot file transcription (no cross-call streaming continuity).
+        var decoderState = try TdtDecoderState()
+        let result = try await asrManager.transcribe(url, decoderState: &decoderState)
         
         guard !isCancelled else {
             throw CancellationError()

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -88,7 +88,11 @@ class FluidAudioEngine: TranscriptionEngine {
         if settings.shouldApplyAsianAutocorrect && !processedText.isEmpty {
             processedText = AutocorrectWrapper.format(processedText)
         }
-        
+
+        if settings.shouldApplyCustomDictionary {
+            processedText = CustomDictionary.apply(processedText, entries: settings.customDictionaryEntries)
+        }
+
         onProgressUpdate?(1.0)
         
         return processedText.isEmpty ? "No speech detected in the audio" : processedText

--- a/OpenSuperWhisper/Engines/WhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/WhisperEngine.swift
@@ -124,7 +124,13 @@ class WhisperEngine: TranscriptionEngine {
         params.detectLanguage = false // means that it only detects the language and does not process the transcription
         params.temperature = Float(settings.temperature)
         params.noSpeechThold = Float(settings.noSpeechThreshold)
-        params.initialPrompt = settings.initialPrompt.isEmpty ? nil : settings.initialPrompt
+        let promptBoost = settings.shouldApplyCustomDictionary
+            ? CustomDictionary.promptBoost(entries: settings.customDictionaryEntries)
+            : ""
+        let combinedPrompt = [settings.initialPrompt, promptBoost]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        params.initialPrompt = combinedPrompt.isEmpty ? nil : combinedPrompt
         
         typealias GGMLAbortCallback = @convention(c) (UnsafeMutableRawPointer?) -> Bool
         let abortCallback: GGMLAbortCallback = { userData in
@@ -203,7 +209,11 @@ class WhisperEngine: TranscriptionEngine {
         if settings.shouldApplyAsianAutocorrect && !cleanedText.isEmpty {
             processedText = AutocorrectWrapper.format(cleanedText)
         }
-        
+
+        if settings.shouldApplyCustomDictionary {
+            processedText = CustomDictionary.apply(processedText, entries: settings.customDictionaryEntries)
+        }
+
         return processedText.isEmpty ? "No speech detected in the audio" : processedText
     }
     

--- a/OpenSuperWhisper/Models/CustomDictionary.swift
+++ b/OpenSuperWhisper/Models/CustomDictionary.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A single custom-dictionary rule: whenever `original` is recognized in a
+/// transcription it is rewritten to `replacement`. Useful for fixing proper
+/// nouns, brand names and domain jargon that the speech models consistently
+/// mis-transcribe (e.g. "git hub" -> "GitHub").
+struct CustomDictionaryEntry: Codable, Identifiable, Equatable, Hashable {
+    var id: UUID
+    var original: String
+    var replacement: String
+
+    init(id: UUID = UUID(), original: String = "", replacement: String = "") {
+        self.id = id
+        self.original = original
+        self.replacement = replacement
+    }
+}
+
+enum CustomDictionary {
+
+    /// Applies the user's dictionary replacements to a transcription.
+    ///
+    /// Matching is case-insensitive and constrained to word boundaries so that
+    /// substrings inside larger words are left untouched (e.g. a rule for "cat"
+    /// will not touch "category"). The replacement string is inserted verbatim,
+    /// preserving the casing the user typed.
+    static func apply(_ text: String, entries: [CustomDictionaryEntry]) -> String {
+        guard !text.isEmpty, !entries.isEmpty else { return text }
+
+        var result = text
+        for entry in entries {
+            let original = entry.original.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !original.isEmpty else { continue }
+
+            let escaped = NSRegularExpression.escapedPattern(for: original)
+            // Only add a \b assertion where the adjacent character of the search
+            // term is itself a word character — otherwise the boundary never
+            // matches for terms that start/end with punctuation (e.g. "C++").
+            let leadingBoundary = isWordCharacter(original.first) ? "\\b" : ""
+            let trailingBoundary = isWordCharacter(original.last) ? "\\b" : ""
+            let pattern = leadingBoundary + escaped + trailingBoundary
+
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+
+            let range = NSRange(result.startIndex..., in: result)
+            let template = NSRegularExpression.escapedTemplate(for: entry.replacement)
+            result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: template)
+        }
+        return result
+    }
+
+    /// Builds an initial-prompt fragment from the dictionary's replacement terms
+    /// so a prompt-conditioned model (Whisper) is biased toward producing the
+    /// correct spelling in the first place. Terms are de-duplicated, order
+    /// preserved.
+    static func promptBoost(entries: [CustomDictionaryEntry]) -> String {
+        var seen = Set<String>()
+        let terms = entries
+            .map { $0.replacement.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+        return terms.joined(separator: ", ")
+    }
+
+    private static func isWordCharacter(_ character: Character?) -> Bool {
+        guard let character = character else { return false }
+        return character.isLetter || character.isNumber || character == "_"
+    }
+}

--- a/OpenSuperWhisper/Models/CustomDictionary.swift
+++ b/OpenSuperWhisper/Models/CustomDictionary.swift
@@ -30,7 +30,12 @@ enum CustomDictionary {
         var result = text
         for entry in entries {
             let original = entry.original.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !original.isEmpty else { continue }
+            let replacement = entry.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Skip incomplete rows. An empty `original` has nothing to match; an empty
+            // `replacement` would silently DELETE every occurrence of `original` from the
+            // output — a natural intermediate state when the user has filled "Heard" but not
+            // yet "Replace with". Both are treated as no-ops rather than data loss.
+            guard !original.isEmpty, !replacement.isEmpty else { continue }
 
             let escaped = NSRegularExpression.escapedPattern(for: original)
             // Only add a \b assertion where the adjacent character of the search
@@ -43,7 +48,9 @@ enum CustomDictionary {
             guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
 
             let range = NSRange(result.startIndex..., in: result)
-            let template = NSRegularExpression.escapedTemplate(for: entry.replacement)
+            // Use the trimmed replacement (consistent with promptBoost) so a stray leading/
+            // trailing space in the rule doesn't produce double spaces in the output.
+            let template = NSRegularExpression.escapedTemplate(for: replacement)
             result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: template)
         }
         return result

--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -234,7 +234,7 @@ class OnboardingViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = unifiedModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1068,10 +1068,10 @@ struct SettingsView: View {
 
                     ForEach($viewModel.customDictionaryEntries) { $entry in
                         HStack(spacing: 8) {
-                            TextField("git hub", text: $entry.original)
+                            TextField("Heard word", text: $entry.original)
                                 .textFieldStyle(.roundedBorder)
                                 .frame(maxWidth: .infinity)
-                            TextField("GitHub", text: $entry.replacement)
+                            TextField("Preferred spelling", text: $entry.replacement)
                                 .textFieldStyle(.roundedBorder)
                                 .frame(maxWidth: .infinity)
                             Button(action: {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -380,7 +380,7 @@ class SettingsViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = downloadableFluidAudioModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1068,10 +1068,12 @@ struct SettingsView: View {
 
                     ForEach($viewModel.customDictionaryEntries) { $entry in
                         HStack(spacing: 8) {
-                            TextField("Heard word", text: $entry.original)
+                            TextField("Heard word", text: $entry.original, prompt: Text("git hub"))
+                                .labelsHidden()
                                 .textFieldStyle(.roundedBorder)
                                 .frame(maxWidth: .infinity)
-                            TextField("Preferred spelling", text: $entry.replacement)
+                            TextField("Preferred spelling", text: $entry.replacement, prompt: Text("GitHub"))
+                                .labelsHidden()
                                 .textFieldStyle(.roundedBorder)
                                 .frame(maxWidth: .infinity)
                             Button(action: {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -93,6 +93,18 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var customDictionaryEnabled: Bool {
+        didSet {
+            AppPreferences.shared.customDictionaryEnabled = customDictionaryEnabled
+        }
+    }
+
+    @Published var customDictionaryEntries: [CustomDictionaryEntry] {
+        didSet {
+            AppPreferences.shared.customDictionaryEntries = customDictionaryEntries
+        }
+    }
+
     @Published var useBeamSearch: Bool {
         didSet {
             AppPreferences.shared.useBeamSearch = useBeamSearch
@@ -165,6 +177,8 @@ class SettingsViewModel: ObservableObject {
         self.temperature = prefs.temperature
         self.noSpeechThreshold = prefs.noSpeechThreshold
         self.initialPrompt = prefs.initialPrompt
+        self.customDictionaryEnabled = prefs.customDictionaryEnabled
+        self.customDictionaryEntries = prefs.customDictionaryEntries
         self.useBeamSearch = prefs.useBeamSearch
         self.beamSize = prefs.beamSize
         self.debugMode = prefs.debugMode
@@ -508,15 +522,21 @@ struct Settings {
     var useBeamSearch: Bool
     var beamSize: Int
     var useAsianAutocorrect: Bool
-    
+    var customDictionaryEnabled: Bool
+    var customDictionaryEntries: [CustomDictionaryEntry]
+
     var isAsianLanguage: Bool {
         Settings.asianLanguages.contains(selectedLanguage)
     }
-    
+
     var shouldApplyAsianAutocorrect: Bool {
         isAsianLanguage && useAsianAutocorrect
     }
-    
+
+    var shouldApplyCustomDictionary: Bool {
+        customDictionaryEnabled && !customDictionaryEntries.isEmpty
+    }
+
     init() {
         let prefs = AppPreferences.shared
         self.selectedLanguage = prefs.whisperLanguage
@@ -529,6 +549,8 @@ struct Settings {
         self.useBeamSearch = prefs.useBeamSearch
         self.beamSize = prefs.beamSize
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
+        self.customDictionaryEnabled = prefs.customDictionaryEnabled
+        self.customDictionaryEntries = prefs.customDictionaryEntries
     }
 }
 
@@ -962,7 +984,10 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color(.controlBackgroundColor).opacity(0.3))
                 .cornerRadius(12)
-                
+
+                // Custom Dictionary
+                customDictionarySection
+
                 // Transcriptions Directory
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Transcriptions Directory")
@@ -1003,6 +1028,82 @@ struct SettingsView: View {
         }
     }
     
+    private var customDictionarySection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Custom Dictionary")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                Spacer()
+                Toggle("", isOn: $viewModel.customDictionaryEnabled)
+                    .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                    .labelsHidden()
+            }
+
+            Text("Replace recognized words with a preferred spelling. Matching is case-insensitive and limited to whole words. With Whisper, the replacements are also used to bias recognition.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            if viewModel.customDictionaryEnabled {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Heard")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text("Replace with")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        // Spacer matching the delete button width.
+                        Color.clear.frame(width: 24, height: 1)
+                    }
+
+                    if viewModel.customDictionaryEntries.isEmpty {
+                        Text("No words yet. Add one below.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.vertical, 4)
+                    }
+
+                    ForEach($viewModel.customDictionaryEntries) { $entry in
+                        HStack(spacing: 8) {
+                            TextField("git hub", text: $entry.original)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: .infinity)
+                            TextField("GitHub", text: $entry.replacement)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: .infinity)
+                            Button(action: {
+                                viewModel.customDictionaryEntries.removeAll { $0.id == entry.id }
+                            }) {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Remove this entry")
+                            .frame(width: 24)
+                        }
+                    }
+
+                    Button(action: {
+                        viewModel.customDictionaryEntries.append(CustomDictionaryEntry())
+                    }) {
+                        Label("Add Word", systemImage: "plus.circle")
+                            .font(.subheadline)
+                    }
+                    .buttonStyle(.borderless)
+                    .padding(.top, 4)
+                }
+                .padding(.top, 4)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor).opacity(0.3))
+        .cornerRadius(12)
+    }
+
     private var advancedSettings: some View {
         Form {
             VStack(spacing: 20) {

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -80,6 +80,26 @@ final class AppPreferences {
     
     @UserDefault(key: "initialPrompt", defaultValue: "")
     var initialPrompt: String
+
+    // Custom dictionary settings
+    @UserDefault(key: "customDictionaryEnabled", defaultValue: false)
+    var customDictionaryEnabled: Bool
+
+    @OptionalUserDefault(key: "customDictionaryData")
+    private var customDictionaryData: Data?
+
+    var customDictionaryEntries: [CustomDictionaryEntry] {
+        get {
+            guard let data = customDictionaryData,
+                  let entries = try? JSONDecoder().decode([CustomDictionaryEntry].self, from: data) else {
+                return []
+            }
+            return entries
+        }
+        set {
+            customDictionaryData = try? JSONEncoder().encode(newValue)
+        }
+    }
     
     @UserDefault(key: "useBeamSearch", defaultValue: false)
     var useBeamSearch: Bool

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -41,6 +41,84 @@ final class WhisperEngineMultiChannelTests: XCTestCase {
     }
 }
 
+final class CustomDictionaryTests: XCTestCase {
+
+    private func entry(_ original: String, _ replacement: String) -> CustomDictionaryEntry {
+        CustomDictionaryEntry(original: original, replacement: replacement)
+    }
+
+    func testApply_replacesWholeWordCaseInsensitively() {
+        let result = CustomDictionary.apply(
+            "I pushed it to git hub yesterday.",
+            entries: [entry("git hub", "GitHub")]
+        )
+        XCTAssertEqual(result, "I pushed it to GitHub yesterday.")
+    }
+
+    func testApply_doesNotReplaceInsideLargerWord() {
+        let result = CustomDictionary.apply(
+            "The category was clear.",
+            entries: [entry("cat", "dog")]
+        )
+        XCTAssertEqual(result, "The category was clear.")
+    }
+
+    func testApply_matchesRegardlessOfInputCasing() {
+        let result = CustomDictionary.apply(
+            "GIT HUB and Git Hub and git hub",
+            entries: [entry("git hub", "GitHub")]
+        )
+        XCTAssertEqual(result, "GitHub and GitHub and GitHub")
+    }
+
+    func testApply_handlesTermsWithPunctuation() {
+        let result = CustomDictionary.apply(
+            "I prefer c plus plus.",
+            entries: [entry("c plus plus", "C++")]
+        )
+        XCTAssertEqual(result, "I prefer C++.")
+    }
+
+    func testApply_treatsReplacementAsLiteralText() {
+        // Replacement contains regex-significant characters; must not be interpreted.
+        let result = CustomDictionary.apply(
+            "ping the channel",
+            entries: [entry("channel", "#general $1")]
+        )
+        XCTAssertEqual(result, "ping the #general $1")
+    }
+
+    func testApply_appliesMultipleEntriesInOrder() {
+        let result = CustomDictionary.apply(
+            "open super whisper uses whisper cpp",
+            entries: [
+                entry("open super whisper", "OpenSuperWhisper"),
+                entry("whisper cpp", "whisper.cpp")
+            ]
+        )
+        XCTAssertEqual(result, "OpenSuperWhisper uses whisper.cpp")
+    }
+
+    func testApply_ignoresEmptyOriginalAndIsNoOpWithoutEntries() {
+        XCTAssertEqual(CustomDictionary.apply("hello", entries: []), "hello")
+        XCTAssertEqual(
+            CustomDictionary.apply("hello", entries: [entry("   ", "x")]),
+            "hello"
+        )
+        XCTAssertEqual(CustomDictionary.apply("", entries: [entry("a", "b")]), "")
+    }
+
+    func testPromptBoost_joinsUniqueReplacements() {
+        let boost = CustomDictionary.promptBoost(entries: [
+            entry("git hub", "GitHub"),
+            entry("g hub", "GitHub"),
+            entry("open super whisper", "OpenSuperWhisper"),
+            entry("noise", "  ")
+        ])
+        XCTAssertEqual(boost, "GitHub, OpenSuperWhisper")
+    }
+}
+
 final class MicrophoneInventoryTests: XCTestCase {
     
     func testPrintConnectedMicrophones() throws {

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ OpenSuperWhisper is a macOS application that provides real-time audio transcript
 - 📁 Drag & drop audio files for transcription with queue processing
 - 🎤 Microphone selection — switch between built-in, external, Bluetooth and iPhone (Apple Continuity) mics from the menu bar
 - 🌍 Support for multiple languages with auto-detection
+- 📖 Custom dictionary — fix proper nouns and jargon with your own replacements (works with both engines; biases Whisper recognition)
 - 🇯🇵🇨🇳🇰🇷 Asian language autocorrect ([autocorrect](https://github.com/huacnlee/autocorrect))
 
 ## Installation
@@ -58,7 +59,7 @@ Contributions are welcome! Please feel free to submit pull requests or create is
 ### Contribution TODO list
 
 - [ ] Streaming transcription
-- [ ] Custom dictionary / keyword boosting ([#19](https://github.com/Starmel/OpenSuperWhisper/issues/19))
+- [x] Custom dictionary / keyword boosting ([#19](https://github.com/Starmel/OpenSuperWhisper/issues/19))
 - [ ] Intel macOS compatibility ([#15](https://github.com/Starmel/OpenSuperWhisper/issues/15))
 - [ ] Agent mode ([#14](https://github.com/Starmel/OpenSuperWhisper/issues/14))
 - [x] Background app ([#8](https://github.com/Starmel/OpenSuperWhisper/issues/8))


### PR DESCRIPTION
## What

Implements the **custom dictionary / keyword boosting** requested in #19: map words the model mishears to a preferred spelling.

- New **Custom Dictionary** section (Transcription settings) for *Heard → Replace with* pairs.
- Whole-word, **case-insensitive** replacement applied to the transcription output.
- With **Whisper**, the replacement terms are also woven into the initial prompt to **bias recognition** toward them.
- Replacements are treated as **literal text** — regex-significant characters (`$1`, `#`, …) are safe.
- Entries with an empty replacement are ignored (they don't delete the heard word).
- Applied on **both** engines (Whisper + Parakeet/FluidAudio).

## Tests

Unit tests cover whole-word matching, case-insensitivity, multi-entry ordering, literal-text replacement, punctuation terms, and prompt-boost joining.

## Also included

- **FluidAudio 0.11.0 → 0.15.2** — needed to build under Xcode 26.5 (0.11 fails Swift 6 `sending` checks). This bump is shared across my feature PRs; happy to drop it if you'd prefer a tighter scope.

Happy to adjust — feedback welcome.
