### PR TITLE
Add Hebrew support: language option + ivrit.ai "Turbo V3 Hebrew" model

### DIFF
--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -509,11 +509,11 @@ struct SettingsDownloadableModels {
             description: "Fastest processing"
         ),
         SettingsDownloadableModel(
-            name: "Hebrew — ivrit.ai Turbo v3",
+            name: "Turbo V3 Hebrew",
             isDownloaded: false,
             url: URL(string: "https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin?download=true")!,
             size: 1624,
-            description: "Hebrew-optimized model by ivrit.ai. Selecting it sets the language to Hebrew.",
+            description: "Hebrew fine-tune of Turbo V3 by ivrit.ai. Sets the language to Hebrew.",
             filename: "ggml-ivrit-large-v3-turbo.bin",
             preferredLanguage: "he"
         )

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -41,6 +41,17 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    /// User-initiated model selection. Persists the model and, if the model declares a
+    /// preferred language (e.g. the ivrit.ai Hebrew model), switches the language to it.
+    /// Do not call from init/restore — only in response to an explicit user action.
+    func selectModel(_ url: URL) {
+        selectedModelURL = url
+        if let lang = SettingsDownloadableModels.preferredLanguage(forFilename: url.lastPathComponent),
+           selectedLanguage != lang {
+            selectedLanguage = lang
+        }
+    }
+
     @Published var availableModels: [URL] = []
     
     @Published var downloadableModels: [SettingsDownloadableModel] = []
@@ -267,7 +278,7 @@ class SettingsViewModel: ObservableObject {
                     }
                     loadAvailableModels()
                     let modelPath = WhisperModelManager.shared.modelsDirectory.appendingPathComponent(filename).path
-                    selectedModelURL = URL(fileURLWithPath: modelPath)
+                    selectModel(URL(fileURLWithPath: modelPath))
                     isDownloading = false
                     downloadingModelName = nil
                     downloadProgress = 0.0
@@ -507,6 +518,10 @@ struct SettingsDownloadableModels {
             preferredLanguage: "he"
         )
     ]
+
+    static func preferredLanguage(forFilename filename: String) -> String? {
+        availableModels.first { $0.filename == filename }?.preferredLanguage
+    }
 }
 
 struct Settings {
@@ -1440,7 +1455,7 @@ struct ModelDownloadItemView: View {
     
     var isSelected: Bool {
         if let selectedURL = viewModel.selectedModelURL {
-            let filename = model.url.lastPathComponent
+            let filename = model.filename
             return selectedURL.lastPathComponent == filename
         }
         return false
@@ -1488,8 +1503,8 @@ struct ModelDownloadItemView: View {
                         .imageScale(.large)
                 } else {
                     Button(action: {
-                        let modelPath = WhisperModelManager.shared.modelsDirectory.appendingPathComponent(model.url.lastPathComponent).path
-                        viewModel.selectedModelURL = URL(fileURLWithPath: modelPath)
+                        let modelPath = WhisperModelManager.shared.modelsDirectory.appendingPathComponent(model.filename).path
+                        viewModel.selectModel(URL(fileURLWithPath: modelPath))
                     }) {
                         Text("Select")
                     }
@@ -1522,8 +1537,8 @@ struct ModelDownloadItemView: View {
         .contentShape(Rectangle())
         .onTapGesture {
             if model.isDownloaded && !isSelected {
-                let modelPath = WhisperModelManager.shared.modelsDirectory.appendingPathComponent(model.url.lastPathComponent).path
-                viewModel.selectedModelURL = URL(fileURLWithPath: modelPath)
+                let modelPath = WhisperModelManager.shared.modelsDirectory.appendingPathComponent(model.filename).path
+                viewModel.selectModel(URL(fileURLWithPath: modelPath))
             }
         }
         .alert("Download Error", isPresented: $showError) {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -207,7 +207,7 @@ class SettingsViewModel: ObservableObject {
         let modelManager = WhisperModelManager.shared
         downloadableModels = SettingsDownloadableModels.availableModels.map { model in
             var updatedModel = model
-            let filename = model.url.lastPathComponent
+            let filename = model.filename
             updatedModel.isDownloaded = modelManager.isModelDownloaded(name: filename)
             return updatedModel
         }
@@ -231,7 +231,7 @@ class SettingsViewModel: ObservableObject {
         
         downloadTask = Task {
             do {
-                let filename = model.url.lastPathComponent
+                let filename = model.filename
                 
                 try await WhisperModelManager.shared.downloadModel(url: model.url, name: filename) { [weak self] progress in
                     Task { @MainActor [weak self] in
@@ -305,7 +305,7 @@ class SettingsViewModel: ObservableObject {
         downloadTask?.cancel()
         if let modelName = downloadingModelName {
             if selectedEngine == "whisper", let model = downloadableModels.first(where: { $0.name == modelName }) {
-                let filename = model.url.lastPathComponent
+                let filename = model.filename
                 WhisperModelManager.shared.cancelDownload(name: filename)
             }
             // Reset progress for the downloading model
@@ -450,6 +450,8 @@ struct SettingsDownloadableModel: Identifiable {
     let size: Int
     let description: String
     var downloadProgress: Double = 0.0
+    let filename: String
+    let preferredLanguage: String?
 
     var sizeString: String {
         let formatter = ByteCountFormatter()
@@ -460,12 +462,15 @@ struct SettingsDownloadableModel: Identifiable {
         return formatter.string(fromByteCount: Int64(size) * 1000000)
     }
 
-    init(name: String, isDownloaded: Bool, url: URL, size: Int, description: String) {
+    init(name: String, isDownloaded: Bool, url: URL, size: Int, description: String,
+         filename: String? = nil, preferredLanguage: String? = nil) {
         self.name = name
         self.isDownloaded = isDownloaded
         self.url = url
         self.size = size
         self.description = description
+        self.filename = filename ?? url.lastPathComponent
+        self.preferredLanguage = preferredLanguage
     }
 }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -496,6 +496,15 @@ struct SettingsDownloadableModels {
             url: URL(string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin?download=true")!,
             size: 574,
             description: "Fastest processing"
+        ),
+        SettingsDownloadableModel(
+            name: "Hebrew — ivrit.ai Turbo v3",
+            isDownloaded: false,
+            url: URL(string: "https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin?download=true")!,
+            size: 1624,
+            description: "Hebrew-optimized model by ivrit.ai. Selecting it sets the language to Hebrew.",
+            filename: "ggml-ivrit-large-v3-turbo.bin",
+            preferredLanguage: "he"
         )
     ]
 }

--- a/OpenSuperWhisper/Utils/LanguageUtil.swift
+++ b/OpenSuperWhisper/Utils/LanguageUtil.swift
@@ -3,7 +3,7 @@ class LanguageUtil {
 
     static let availableLanguages = [
         "auto", "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
-        "sv", "it", "id", "hi", "fi",
+        "he", "sv", "it", "id", "hi", "fi",
     ]
 
     static let languageNames = [
@@ -22,6 +22,7 @@ class LanguageUtil {
         "ca": "Catalan",
         "nl": "Dutch",
         "ar": "Arabic",
+        "he": "Hebrew",
         "sv": "Swedish",
         "it": "Italian",
         "id": "Indonesian",

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1145,4 +1145,19 @@ final class HebrewIvritSupportTests: XCTestCase {
         XCTAssertEqual(ivrit?.url.host, "huggingface.co")
         XCTAssertTrue(ivrit?.url.absoluteString.contains("ivrit-ai/whisper-large-v3-turbo-ggml") ?? false)
     }
+
+    // MARK: Task 4 — preferred-language lookup
+    func testPreferredLanguageLookupForIvritModel() {
+        XCTAssertEqual(
+            SettingsDownloadableModels.preferredLanguage(forFilename: "ggml-ivrit-large-v3-turbo.bin"),
+            "he")
+    }
+
+    func testPreferredLanguageLookupForStandardModelIsNil() {
+        XCTAssertNil(SettingsDownloadableModels.preferredLanguage(forFilename: "ggml-large-v3-turbo.bin"))
+    }
+
+    func testPreferredLanguageLookupForUnknownFilenameIsNil() {
+        XCTAssertNil(SettingsDownloadableModels.preferredLanguage(forFilename: "does-not-exist.bin"))
+    }
 }

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1100,3 +1100,12 @@ final class TextUtilTests: XCTestCase {
         XCTAssertEqual(TextUtil.formatDuration(3600), "1h 0m 0s")
     }
 }
+
+final class HebrewIvritSupportTests: XCTestCase {
+
+    // MARK: Task 1 — Hebrew language
+    func testHebrewIsAvailableLanguage() {
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("he"))
+        XCTAssertEqual(LanguageUtil.languageNames["he"], "Hebrew")
+    }
+}

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1108,4 +1108,30 @@ final class HebrewIvritSupportTests: XCTestCase {
         XCTAssertTrue(LanguageUtil.availableLanguages.contains("he"))
         XCTAssertEqual(LanguageUtil.languageNames["he"], "Hebrew")
     }
+
+    // MARK: Task 2 — model struct filename/preferredLanguage
+    func testDownloadableModelDefaultsFilenameToURLBasename() {
+        let model = SettingsDownloadableModel(
+            name: "X", isDownloaded: false,
+            url: URL(string: "https://example.com/path/ggml-foo.bin?download=true")!,
+            size: 1, description: "d")
+        XCTAssertEqual(model.filename, "ggml-foo.bin")
+        XCTAssertNil(model.preferredLanguage)
+    }
+
+    func testDownloadableModelHonorsExplicitFilenameAndLanguage() {
+        let model = SettingsDownloadableModel(
+            name: "X", isDownloaded: false,
+            url: URL(string: "https://example.com/ggml-model.bin?download=true")!,
+            size: 1, description: "d",
+            filename: "ggml-custom.bin", preferredLanguage: "he")
+        XCTAssertEqual(model.filename, "ggml-custom.bin")
+        XCTAssertEqual(model.preferredLanguage, "he")
+    }
+
+    func testExistingStandardModelsKeepURLBasenameFilenames() {
+        for m in SettingsDownloadableModels.availableModels where m.preferredLanguage == nil {
+            XCTAssertEqual(m.filename, m.url.lastPathComponent)
+        }
+    }
 }

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1134,4 +1134,15 @@ final class HebrewIvritSupportTests: XCTestCase {
             XCTAssertEqual(m.filename, m.url.lastPathComponent)
         }
     }
+
+    // MARK: Task 3 — ivrit.ai model entry
+    func testIvritModelIsAvailableWithCorrectMetadata() {
+        let ivrit = SettingsDownloadableModels.availableModels.first {
+            $0.filename == "ggml-ivrit-large-v3-turbo.bin"
+        }
+        XCTAssertNotNil(ivrit)
+        XCTAssertEqual(ivrit?.preferredLanguage, "he")
+        XCTAssertEqual(ivrit?.url.host, "huggingface.co")
+        XCTAssertTrue(ivrit?.url.absoluteString.contains("ivrit-ai/whisper-large-v3-turbo-ggml") ?? false)
+    }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -74,4 +74,4 @@ You can download Whisper model files (`.bin`) from the [Whisper.cpp Hugging Face
 
 ### Hebrew (ivrit.ai)
 
-For Hebrew transcription, download the **"Hebrew — ivrit.ai Turbo v3"** model from Settings → Model. It is the [ivrit.ai](https://www.ivrit.ai/) Hebrew-optimized Whisper model ([whisper-large-v3-turbo-ggml](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml)). Selecting it automatically sets the input language to Hebrew — these models are tuned for Hebrew and require the language to be set explicitly.
+For Hebrew transcription, download the **"Turbo V3 Hebrew"** model from Settings → Model. It is [ivrit.ai](https://www.ivrit.ai/)'s Hebrew fine-tune of `whisper-large-v3-turbo` ([whisper-large-v3-turbo-ggml](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml)) — the same base model as the other "Turbo V3" entries, but tuned for Hebrew. Selecting it automatically sets the input language to Hebrew, which these models require to be set explicitly.

--- a/Readme.md
+++ b/Readme.md
@@ -71,3 +71,7 @@ OpenSuperWhisper is licensed under the MIT License. See the [LICENSE](LICENSE) f
 ## Whisper Models
 
 You can download Whisper model files (`.bin`) from the [Whisper.cpp Hugging Face repository](https://huggingface.co/ggerganov/whisper.cpp/tree/main). Place the downloaded `.bin` files in the app's models directory. On first launch, the app will attempt to copy a default model automatically, but you can add more models manually.
+
+### Hebrew (ivrit.ai)
+
+For Hebrew transcription, download the **"Hebrew — ivrit.ai Turbo v3"** model from Settings → Model. It is the [ivrit.ai](https://www.ivrit.ai/) Hebrew-optimized Whisper model ([whisper-large-v3-turbo-ggml](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml)). Selecting it automatically sets the input language to Hebrew — these models are tuned for Hebrew and require the language to be set explicitly.


### PR DESCRIPTION
## Summary

Adds Hebrew support to OpenSuperWhisper:

- **Hebrew (`he`) as a selectable input language** — in Settings → Transcription and the menu-bar language menu. whisper.cpp already supports the `he` token; it was simply missing from the app's language list.
- **"Turbo V3 Hebrew" downloadable model** — [ivrit.ai](https://www.ivrit.ai/)'s Hebrew fine-tune of `whisper-large-v3-turbo` ([ivrit-ai/whisper-large-v3-turbo-ggml](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml)). Same base model as the existing "Turbo V3" entries, tuned for Hebrew. Saved on disk as `ggml-ivrit-large-v3-turbo.bin`.
- **Auto-selects Hebrew when that model is chosen.** ivrit.ai's models have intentionally degraded language auto-detection and need the language set explicitly, so selecting the model sets the input language to Hebrew — only on explicit user selection, never on launch/restore, so a manually chosen language is never overridden.

### Implementation notes

- `SettingsDownloadableModel` gains an optional `filename` (defaults to the URL's last path component, so the three existing entries are unchanged) and `preferredLanguage`. The explicit `filename` gives the Hebrew model a descriptive, collision-free on-disk name and picker label — the source repo ships its file as a generic `ggml-model.bin`.
- User-initiated model selection now routes through a small `SettingsViewModel.selectModel(_:)` choke point that applies a model's `preferredLanguage`.
- Scope kept tight: Settings model list only (onboarding picker unchanged), turbo variant only.

## Test plan

- [x] Builds on Apple Silicon (verified on Xcode 26.5)
- [x] New unit tests in `OpenSuperWhisperTests` pass — Hebrew in the language list, ivrit model metadata, preferred-language lookup
- [x] Existing models still download/select correctly (filename defaults unchanged)
- [x] End-to-end: downloaded "Turbo V3 Hebrew", language auto-set to Hebrew, Hebrew audio transcribed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)