### PR TITLE
Fix build on Xcode 26.5: bump FluidAudio 0.11.0 → 0.15.4 and migrate AsrManager API

### DIFF
--- a/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "5d9176eb35bcbe009c7b26202f0e92c85ff2dedf",
-        "version" : "0.11.0"
+        "revision" : "b9d43724cbdb5a980e441fd54180964e94d470f7",
+        "version" : "0.15.4"
       }
     },
     {

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -23,7 +23,7 @@ class FluidAudioEngine: TranscriptionEngine {
         
         let models = try await AsrModels.downloadAndLoad(version: version)
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
+        try await manager.loadModels(models)
         
         asrManager = manager
         asrModels = models
@@ -74,7 +74,9 @@ class FluidAudioEngine: TranscriptionEngine {
         }
         
         // Perform actual transcription - FluidAudio will emit progress automatically
-        let result = try await asrManager.transcribe(url)
+        // FluidAudio 0.15.x requires an explicit decoder state per transcription.
+        var decoderState = try TdtDecoderState(decoderLayers: await asrManager.decoderLayerCount)
+        let result = try await asrManager.transcribe(url, decoderState: &decoderState)
         
         guard !isCancelled else {
             throw CancellationError()

--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -234,7 +234,7 @@ class OnboardingViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = unifiedModels.firstIndex(where: { $0.id == model.id }) {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -366,7 +366,7 @@ class SettingsViewModel: ObservableObject {
                 }
                 
                 let manager = AsrManager(config: .default)
-                try await manager.initialize(models: models)
+                try await manager.loadModels(models)
                 
                 await MainActor.run {
                     if let index = downloadableFluidAudioModels.firstIndex(where: { $0.id == model.id }) {


### PR DESCRIPTION
## Problem

hey @Starmel! quick fix, quick win - current build is failing on later versions of xcode which i think people are going to start building with, so just updating one of the dependencies within :) figured you'll be tired of ai PRs but this is a easy (and necessary!) win

On **Xcode 26.5** (Swift 6.x toolchain) the build fails inside the pinned `FluidAudio` dependency (**v0.11.0**), before any of this app's own code is reached:

```
SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift:258/379/621:
error: sending 'asrManager' risks causing data races
** BUILD FAILED **
```

FluidAudio's manifest is `swift-tools-version: 6.0` with no `swiftLanguageMode(.v5)` override, so its targets compile in **Swift 6 language mode**, where these region-based actor-isolation violations are hard errors. v0.11.0 predates the stricter checks in the compiler shipped with Xcode 26.5, so the dependency no longer compiles on current toolchains. (Older Xcode versions didn't flag it, which is why existing release builds were unaffected.)

## Fix

- **Bump `FluidAudio` 0.11.0 → 0.15.4.** The offending streaming file was restructured upstream and the concurrency errors are gone. The Swift Package requirement was already `upToNextMajorVersion` from `0.7.9`, so only `Package.resolved` needed updating — no `project.pbxproj` change.
- **Migrate the small `AsrManager` API surface** the app uses (0.15.x changed it):
  - `manager.initialize(models:)` → `manager.loadModels(_:)` — 3 call sites (`FluidAudioEngine`, `Settings`, `OnboardingView`).
  - `transcribe(_:)` → `transcribe(_:decoderState:)`. 0.15.x exposes the TDT decoder state explicitly (for streaming continuity); for one-shot file transcription a fresh `TdtDecoderState` per call matches the previous behavior. The state is sized via `asrManager.decoderLayerCount` so it stays correct across model versions.

## Testing

- `./run.sh build` → `Building successful!`
- App launches and runs without crashing.
- Verified the FluidAudio (Parakeet v3) transcription path end-to-end on the repo's `jfk.wav` using the migrated calls:
  > And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.

## Notes

This only addresses the FluidAudio build break on Xcode 26.5; no behavior changes intended.
