### PR TITLE
Add no microphone state handling and tests for recording functionality

### DIFF
--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -157,6 +157,8 @@ class ContentViewModel: ObservableObject {
     }
     
     func startRecording() {
+        guard microphoneService.getActiveMicrophone() != nil else { return }
+
         if microphoneService.isActiveMicrophoneRequiresConnection() {
             state = .connecting
             stopBlinking()
@@ -508,7 +510,7 @@ struct ContentView: View {
                             }
                         }
                         .buttonStyle(.plain)
-                        .disabled(viewModel.transcriptionService.isLoading || viewModel.transcriptionService.isTranscribing || viewModel.transcriptionQueue.isProcessing || viewModel.state == .decoding)
+                        .disabled(viewModel.transcriptionService.isLoading || viewModel.transcriptionService.isTranscribing || viewModel.transcriptionQueue.isProcessing || viewModel.state == .decoding || viewModel.microphoneService.availableMicrophones.isEmpty)
                         .padding(.top, 24)
                         .padding(.bottom, 16)
                         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: viewModel.isRecording)

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -8,6 +8,7 @@ enum RecordingState {
     case recording
     case decoding
     case busy
+    case noMicrophone
 }
 
 @MainActor
@@ -65,8 +66,12 @@ class IndicatorViewModel: ObservableObject {
     }
     
     func showBusyMessage() {
-        state = .busy
-        
+        showAutoDismissingMessage(.busy)
+    }
+
+    private func showAutoDismissingMessage(_ message: RecordingState) {
+        state = message
+
         hideTimer?.invalidate()
         hideTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
             Task { @MainActor in
@@ -74,13 +79,18 @@ class IndicatorViewModel: ObservableObject {
             }
         }
     }
-    
+
     func startRecording() {
         if isTranscriptionBusy {
             showBusyMessage()
             return
         }
-        
+
+        guard MicrophoneService.shared.getActiveMicrophone() != nil else {
+            showAutoDismissingMessage(.noMicrophone)
+            return
+        }
+
         if MicrophoneService.shared.isActiveMicrophoneRequiresConnection() {
             state = .connecting
             stopBlinking()
@@ -314,13 +324,25 @@ struct IndicatorWindow: View {
                     Image(systemName: "hourglass")
                         .foregroundColor(.orange)
                         .frame(width: 24)
-                    
+
                     Text("Processing...")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(.orange)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                
+
+            case .noMicrophone:
+                HStack(spacing: 8) {
+                    Image(systemName: "mic.slash")
+                        .foregroundColor(.orange)
+                        .frame(width: 24)
+
+                    Text("No microphone")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
             case .idle:
                 EmptyView()
             }

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1046,6 +1046,54 @@ final class AddSpaceAfterSentenceTests: XCTestCase {
     }
 }
 
+@MainActor
+final class NoMicrophoneGuardTests: XCTestCase {
+
+    /// Forces `MicrophoneService.shared` to report no active microphone for the
+    /// duration of `body`, restoring the previous state afterwards.
+    private func withNoMicrophone(_ body: () -> Void) {
+        let service = MicrophoneService.shared
+        let savedSelected = service.selectedMicrophone
+        let savedCurrent = service.currentMicrophone
+
+        service.selectedMicrophone = nil
+        service.currentMicrophone = nil
+        defer {
+            service.selectedMicrophone = savedSelected
+            service.currentMicrophone = savedCurrent
+        }
+
+        XCTAssertNil(service.getActiveMicrophone(), "Precondition: no active microphone")
+        body()
+    }
+
+    func testIndicatorViewModel_startRecording_withNoMicrophone_showsNoMicrophoneState() {
+        withNoMicrophone {
+            let viewModel = IndicatorViewModel()
+            viewModel.startRecording()
+
+            XCTAssertTrue(viewModel.state == .noMicrophone,
+                          "Indicator should show the no-microphone state instead of a fake 'recording' state")
+            XCTAssertFalse(viewModel.recorder.isRecording,
+                           "Recorder must not be recording when there is no microphone")
+
+            viewModel.cleanup()
+        }
+    }
+
+    func testContentViewModel_startRecording_withNoMicrophone_doesNotStartRecording() {
+        withNoMicrophone {
+            let viewModel = ContentViewModel()
+            viewModel.startRecording()
+
+            XCTAssertTrue(viewModel.state == .idle,
+                          "In-app recording must not begin when there is no microphone")
+            XCTAssertFalse(viewModel.recorder.isRecording,
+                           "Recorder must not be recording when there is no microphone")
+        }
+    }
+}
+
 final class TextUtilTests: XCTestCase {
 
     // MARK: - wordCount


### PR DESCRIPTION
## Problem

When no input device is available, starting a recording gave no usable feedback:

- **Hotkey mini-recorder:** it showed a blinking **"Recording…"** indicator that never progressed. `AudioRecorder.startRecording()` bails at its `canRecord` guard, so nothing is captured; on stop, `stopRecording()` returns `nil` and the indicator is left hanging.
- **In-app record button:** it optimistically entered a "recording" state for the same reason.

In both cases the UI implied recording was happening while nothing was, with no hint that a microphone is required.

## Fix

- **Indicator (hotkey):** `IndicatorViewModel.startRecording()` now checks `MicrophoneService.getActiveMicrophone()` and, when there is no device, shows a self-dismissing **"No microphone"** indicator (`mic.slash`) instead of a fake recording state. This reuses the existing transient-message pattern (`showBusyMessage`), extracted into a shared `showAutoDismissingMessage(_:)` helper to avoid duplication.
- **In-app button:** `ContentViewModel.startRecording()` guards the same way, and the record button is disabled when no microphones are available — consistent with the existing mic picker, which already keys off `availableMicrophones.isEmpty`.

Right now, it looks like:
<img width="475" height="151" alt="image" src="https://github.com/user-attachments/assets/03ef1e0e-5228-41da-86ce-ff40e2e429d4" />

## Testing

- Added `NoMicrophoneGuardTests` covering both guard paths (indicator and in-app view models).
- Verified manually on a Mac with no microphone: the hotkey shows the "No microphone" pill and auto-dismisses; the in-app record button is disabled.
- Full app builds; `xcodebuild test` for the new tests passes.