### PR TITLE
Don't paste 'No speech detected' when recording is silent

### DIFF
--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -93,7 +93,7 @@ class FluidAudioEngine: TranscriptionEngine {
         
         onProgressUpdate?(1.0)
         
-        return processedText.isEmpty ? "No speech detected in the audio" : processedText
+        return processedText
     }
     
     func cancelTranscription() {

--- a/OpenSuperWhisper/Engines/WhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/WhisperEngine.swift
@@ -204,7 +204,7 @@ class WhisperEngine: TranscriptionEngine {
             processedText = AutocorrectWrapper.format(cleanedText)
         }
         
-        return processedText.isEmpty ? "No speech detected in the audio" : processedText
+        return processedText
     }
     
     func cancelTranscription() {

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -169,6 +169,7 @@ class IndicatorViewModel: ObservableObject {
     }
     
     func insertText(_ text: String) {
+        guard !text.isEmpty else { return }
         let finalText = Self.applyPostProcessing(text)
         let prefs = AppPreferences.shared
 


### PR DESCRIPTION
Fixes #159

## Problem

When you trigger a recording and say nothing, the app pastes the literal string `No speech detected in the audio` into whatever field has focus -- a terminal, chat input, document, etc.

## Changes

Three files, three lines:

**`WhisperEngine.swift` + `FluidAudioEngine.swift`** -- return empty string instead of the error message when no speech is detected:
```swift
// before
return processedText.isEmpty ? "No speech detected in the audio" : processedText
// after
return processedText
```

**`IndicatorWindow.swift`** -- guard against empty text before touching the clipboard or simulating a paste:
```swift
func insertText(_ text: String) {
    guard !text.isEmpty else { return }  // new
    // ...
}
```

The recording is still saved to history, and the UI can still show "No speech detected" there. This only stops the text from being pasted into the active app.