### PR TITLE
Add option to remove filler words from transcription output

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -189,12 +189,27 @@ class IndicatorViewModel: ObservableObject {
     }
     
     static func applyPostProcessing(_ text: String) -> String {
-        guard AppPreferences.shared.addSpaceAfterSentence,
-              let lastChar = text.last,
-              lastChar.isPunctuation else {
-            return text
+        var result = text
+
+        if AppPreferences.shared.removeFillerWords {
+            let fillers = ["um", "uh", "er", "erm", "ah", "hm", "hmm"]
+            for filler in fillers {
+                result = result.replacingOccurrences(
+                    of: "\\b\(filler)\\b",
+                    with: "",
+                    options: [.regularExpression, .caseInsensitive]
+                )
+            }
+            result = result.replacingOccurrences(of: "  ", with: " ").trimmingCharacters(in: .whitespaces)
         }
-        return text + " "
+
+        if AppPreferences.shared.addSpaceAfterSentence,
+           let lastChar = result.last,
+           lastChar.isPunctuation {
+            result += " "
+        }
+
+        return result
     }
     
     private func startBlinking() {

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -192,15 +192,15 @@ class IndicatorViewModel: ObservableObject {
         var result = text
 
         if AppPreferences.shared.removeFillerWords {
-            let fillers = ["um", "uh", "er", "erm", "ah", "hm", "hmm"]
+            let fillers = ["um", "uh"]
             for filler in fillers {
                 result = result.replacingOccurrences(
-                    of: "\\b\(filler)\\b",
-                    with: "",
+                    of: "[,\\s]*\\b\(filler)\\b[,\\s]*",
+                    with: " ",
                     options: [.regularExpression, .caseInsensitive]
                 )
             }
-            result = result.replacingOccurrences(of: "  ", with: " ").trimmingCharacters(in: .whitespaces)
+            result = result.trimmingCharacters(in: .whitespaces)
         }
 
         if AppPreferences.shared.addSpaceAfterSentence,

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -200,7 +200,9 @@ class IndicatorViewModel: ObservableObject {
                     options: [.regularExpression, .caseInsensitive]
                 )
             }
-            result = result.trimmingCharacters(in: .whitespaces)
+            result = result
+                .replacingOccurrences(of: "  +", with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespaces)
         }
 
         if AppPreferences.shared.addSpaceAfterSentence,

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -142,6 +142,12 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var removeFillerWords: Bool {
+        didSet {
+            AppPreferences.shared.removeFillerWords = removeFillerWords
+        }
+    }
+
     @Published var autoCopyToClipboard: Bool {
         didSet {
             AppPreferences.shared.autoCopyToClipboard = autoCopyToClipboard
@@ -173,6 +179,7 @@ class SettingsViewModel: ObservableObject {
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
         self.holdToRecord = prefs.holdToRecord
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
+        self.removeFillerWords = prefs.removeFillerWords
         self.autoCopyToClipboard = prefs.autoCopyToClipboard
         self.autoPasteTranscription = prefs.autoPasteTranscription
 
@@ -888,6 +895,19 @@ struct SettingsView: View {
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
                                 .labelsHidden()
                         }
+                    }
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Remove Filler Words")
+                                .font(.subheadline)
+                            Text("Strips um, uh, er, erm, ah, hm, hmm from transcription output")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: $viewModel.removeFillerWords)
+                            .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                            .labelsHidden()
                     }
                 }
                 .padding()

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -900,7 +900,7 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Remove Filler Words")
                                 .font(.subheadline)
-                            Text("Strips um, uh, er, erm, ah, hm, hmm from transcription output")
+                            Text("Strips um and uh from transcription output")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -117,4 +117,7 @@ final class AppPreferences {
 
     @UserDefault(key: "autoPasteTranscription", defaultValue: true)
     var autoPasteTranscription: Bool
+
+    @UserDefault(key: "removeFillerWords", defaultValue: false)
+    var removeFillerWords: Bool
 }

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1046,6 +1046,53 @@ final class AddSpaceAfterSentenceTests: XCTestCase {
     }
 }
 
+@MainActor
+final class RemoveFillerWordsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        AppPreferences.shared.removeFillerWords = true
+        AppPreferences.shared.addSpaceAfterSentence = false
+    }
+
+    override func tearDown() {
+        AppPreferences.shared.removeFillerWords = false
+        AppPreferences.shared.addSpaceAfterSentence = true
+        super.tearDown()
+    }
+
+    func testRemovesUm() {
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("Um yeah I think so"), "yeah I think so")
+    }
+
+    func testRemovesUh() {
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("I uh think so"), "I think so")
+    }
+
+    func testCaseInsensitive() {
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("UM yeah"), "yeah")
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("UH yeah"), "yeah")
+    }
+
+    func testAbsorbsSurroundingComma() {
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("Um, I think"), "I think")
+    }
+
+    func testDoubleFillerNoExtraSpace() {
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("I um uh think"), "I think")
+    }
+
+    func testWholeWordOnly() {
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("umbrella"), "umbrella")
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("dumb"), "dumb")
+    }
+
+    func testDisabledLeavesTextUnchanged() {
+        AppPreferences.shared.removeFillerWords = false
+        XCTAssertEqual(IndicatorViewModel.applyPostProcessing("Um yeah"), "Um yeah")
+    }
+}
+
 final class TextUtilTests: XCTestCase {
 
     // MARK: - wordCount


### PR DESCRIPTION
Closes #161

## Summary

Adds a **Remove Filler Words** toggle in Settings → Transcription. When enabled, strips `um` and `uh` from transcribed text before pasting. Off by default so existing behavior is unchanged.

Only `um` and `uh` are filtered -- other candidates (`er`, `ah`, `hmm`, `erm`) were excluded because they have common legitimate uses (ER, H&M, "hmm I'll think about it") that would cause false positives.

The regex absorbs surrounding commas and whitespace so "Um, I think" → "I think" rather than leaving a dangling comma. Consecutive fillers ("um uh") collapse cleanly with no double spaces.

## Changes

- `AppPreferences.swift` — adds `removeFillerWords: Bool` preference (default `false`)
- `Settings.swift` — adds published property + UI toggle alongside "Add Space After Sentence"
- `IndicatorWindow.swift` — extends `applyPostProcessing()` to strip fillers when enabled
- `OpenSuperWhisperTests.swift` — adds `RemoveFillerWordsTests` (7 cases, all passing locally)

## Test plan

- [x] Builds on Apple Silicon (verified locally with `run.sh build`)
- [x] All 7 unit tests pass locally
- [x] Toggle off (default): transcription output unchanged
- [x] Toggle on: "Um yeah I think so" → "yeah I think so"
- [x] Toggle on: "Um, I think" → "I think" (no dangling comma)
- [x] Double filler: "I um uh think" → "I think" (no double space)
- [x] Case-insensitive: "UM", "Um", "um" all stripped
- [x] Whole-word only: "umbrella", "dumb" unaffected
- [x] Existing "Add Space After Sentence" behavior unaffected