### PR TITLE
feat: add mouse button as a recording trigger

### DIFF
--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -302,6 +302,10 @@ struct ContentView: View {
     @State private var searchTask: Task<Void, Never>? = nil
 
     private var currentShortcutDescription: String {
+        let mouseButton = MouseButton(rawValue: AppPreferences.shared.mouseButtonHotkey) ?? .none
+        if mouseButton != .none {
+            return mouseButton.shortSymbol
+        }
         let modifierKey = ModifierKey(rawValue: AppPreferences.shared.modifierOnlyHotkey) ?? .none
         if modifierKey != .none {
             return modifierKey.shortSymbol

--- a/OpenSuperWhisper/MouseButtonMonitor.swift
+++ b/OpenSuperWhisper/MouseButtonMonitor.swift
@@ -1,0 +1,169 @@
+import AppKit
+import Carbon
+import Foundation
+
+enum MouseButton: String, CaseIterable, Identifiable, Codable {
+    case none = "none"
+    case middle = "middle"
+    case button4 = "button4"
+    case button5 = "button5"
+    case button6 = "button6"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .none: return "None"
+        case .middle: return "Button 3 (Middle)"
+        case .button4: return "Button 4 (Back)"
+        case .button5: return "Button 5 (Forward)"
+        case .button6: return "Button 6"
+        }
+    }
+
+    var shortSymbol: String {
+        switch self {
+        case .none: return ""
+        case .middle: return "🖱3"
+        case .button4: return "🖱4"
+        case .button5: return "🖱5"
+        case .button6: return "🖱6"
+        }
+    }
+
+    /// The `buttonNumber` reported by CGEvent's `.mouseEventButtonNumber` field.
+    /// macOS numbers buttons from zero: 0 = left, 1 = right, 2 = middle, 3+ = extra
+    /// (thumb / side) buttons. The user-facing names above use the common one-based
+    /// convention (left = Button 1), so each case maps to `buttonNumber - 1`.
+    var buttonNumber: Int64 {
+        switch self {
+        case .none: return -1
+        case .middle: return 2
+        case .button4: return 3
+        case .button5: return 4
+        case .button6: return 5
+        }
+    }
+}
+
+class MouseButtonMonitor {
+    static let shared = MouseButtonMonitor()
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var selectedMouseButton: MouseButton = .none
+    private var isButtonPressed = false
+
+    var onButtonDown: (() -> Void)?
+    var onButtonUp: (() -> Void)?
+
+    private init() {}
+
+    func start(mouseButton: MouseButton) {
+        guard mouseButton != .none else {
+            stop()
+            return
+        }
+
+        stop()
+
+        selectedMouseButton = mouseButton
+        isButtonPressed = false
+
+        let eventMask = CGEventMask(
+            (1 << CGEventType.otherMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseUp.rawValue)
+        )
+
+        // A default (not listen-only) tap so the bound button can be consumed and
+        // used purely as a recording trigger, without also firing its normal action
+        // (e.g. browser back/forward) in the focused app.
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: { (proxy, type, event, refcon) -> Unmanaged<CGEvent>? in
+                guard let refcon = refcon else {
+                    return Unmanaged.passUnretained(event)
+                }
+
+                let monitor = Unmanaged<MouseButtonMonitor>.fromOpaque(refcon).takeUnretainedValue()
+
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    monitor.reenableTap()
+                    return Unmanaged.passUnretained(event)
+                }
+
+                if monitor.handleMouseEvent(type: type, event: event) {
+                    // Matched the bound button — consume the event.
+                    return nil
+                }
+                return Unmanaged.passUnretained(event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            print("MouseButtonMonitor: Failed to create event tap. Check accessibility permissions.")
+            return
+        }
+
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+            CGEvent.tapEnable(tap: tap, enable: true)
+            print("MouseButtonMonitor: Started monitoring for \(mouseButton.displayName)")
+        }
+    }
+
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+            }
+        }
+        eventTap = nil
+        runLoopSource = nil
+        isButtonPressed = false
+        print("MouseButtonMonitor: Stopped")
+    }
+
+    fileprivate func reenableTap() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+            print("MouseButtonMonitor: Re-enabled tap after timeout")
+        }
+    }
+
+    /// Returns `true` when the event belongs to the bound button and should be consumed.
+    private func handleMouseEvent(type: CGEventType, event: CGEvent) -> Bool {
+        let buttonNumber = event.getIntegerValueField(.mouseEventButtonNumber)
+        guard buttonNumber == selectedMouseButton.buttonNumber else { return false }
+
+        switch type {
+        case .otherMouseDown:
+            if !isButtonPressed {
+                isButtonPressed = true
+                DispatchQueue.main.async {
+                    self.onButtonDown?()
+                }
+            }
+        case .otherMouseUp:
+            if isButtonPressed {
+                isButtonPressed = false
+                DispatchQueue.main.async {
+                    self.onButtonUp?()
+                }
+            }
+        default:
+            return false
+        }
+        return true
+    }
+
+    deinit {
+        stop()
+    }
+}

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -129,6 +129,13 @@ class SettingsViewModel: ObservableObject {
             NotificationCenter.default.post(name: .hotkeySettingsChanged, object: nil)
         }
     }
+
+    @Published var mouseButtonHotkey: MouseButton {
+        didSet {
+            AppPreferences.shared.mouseButtonHotkey = mouseButtonHotkey.rawValue
+            NotificationCenter.default.post(name: .hotkeySettingsChanged, object: nil)
+        }
+    }
     
     @Published var holdToRecord: Bool {
         didSet {
@@ -171,6 +178,7 @@ class SettingsViewModel: ObservableObject {
         self.playSoundOnRecordStart = prefs.playSoundOnRecordStart
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
+        self.mouseButtonHotkey = MouseButton(rawValue: prefs.mouseButtonHotkey) ?? .none
         self.holdToRecord = prefs.holdToRecord
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
         self.autoCopyToClipboard = prefs.autoCopyToClipboard
@@ -1106,8 +1114,16 @@ struct SettingsView: View {
         }
     }
     
-    private var useModifierKey: Bool {
-        viewModel.modifierOnlyHotkey != .none
+    private enum TriggerMode: Hashable {
+        case keyCombo
+        case modifier
+        case mouse
+    }
+
+    private var triggerMode: TriggerMode {
+        if viewModel.mouseButtonHotkey != .none { return .mouse }
+        if viewModel.modifierOnlyHotkey != .none { return .modifier }
+        return .keyCombo
     }
     
     private var shortcutSettings: some View {
@@ -1121,21 +1137,33 @@ struct SettingsView: View {
                     
                     VStack(alignment: .leading, spacing: 16) {
                         Picker("", selection: Binding(
-                            get: { useModifierKey },
-                            set: { newValue in
-                                if !newValue {
+                            get: { triggerMode },
+                            set: { newMode in
+                                switch newMode {
+                                case .keyCombo:
+                                    viewModel.mouseButtonHotkey = .none
                                     viewModel.modifierOnlyHotkey = .none
-                                } else if viewModel.modifierOnlyHotkey == .none {
-                                    viewModel.modifierOnlyHotkey = .leftCommand
+                                case .modifier:
+                                    viewModel.mouseButtonHotkey = .none
+                                    if viewModel.modifierOnlyHotkey == .none {
+                                        viewModel.modifierOnlyHotkey = .leftCommand
+                                    }
+                                case .mouse:
+                                    viewModel.modifierOnlyHotkey = .none
+                                    if viewModel.mouseButtonHotkey == .none {
+                                        viewModel.mouseButtonHotkey = .middle
+                                    }
                                 }
                             }
                         )) {
-                            Text("Key Combination").tag(false)
-                            Text("Single Modifier Key").tag(true)
+                            Text("Key Combination").tag(TriggerMode.keyCombo)
+                            Text("Single Modifier Key").tag(TriggerMode.modifier)
+                            Text("Mouse Button").tag(TriggerMode.mouse)
                         }
                         .pickerStyle(.segmented)
-                        
-                        if useModifierKey {
+
+                        switch triggerMode {
+                        case .modifier:
                             VStack(alignment: .leading, spacing: 8) {
                                 HStack {
                                     Text("Modifier Key")
@@ -1153,7 +1181,7 @@ struct SettingsView: View {
                                 .padding(.vertical, 10)
                                 .background(Color(.textBackgroundColor).opacity(0.5))
                                 .cornerRadius(8)
-                                
+
                                 Text("One-tap to toggle recording")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
@@ -1163,7 +1191,35 @@ struct SettingsView: View {
                                     .foregroundColor(.orange)
                                     .padding(.top, 4)
                             }
-                        } else {
+                        case .mouse:
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    Text("Mouse Button")
+                                        .font(.subheadline)
+                                    Spacer()
+                                    Picker("", selection: $viewModel.mouseButtonHotkey) {
+                                        ForEach(MouseButton.allCases.filter { $0 != .none }) { button in
+                                            Text(button.displayName).tag(button)
+                                        }
+                                    }
+                                    .pickerStyle(.menu)
+                                    .frame(width: 200)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 10)
+                                .background(Color(.textBackgroundColor).opacity(0.5))
+                                .cornerRadius(8)
+
+                                Text("Click to toggle recording, or hold when Hold to Record is on. The left and right buttons are reserved — pick the middle or an extra (thumb) button.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+
+                                Text("⚠️ This mode requires Accessibility permission so the button can be detected globally and used only as a recording trigger. Only the selected mouse button is intercepted — no other clicks or keystrokes are captured.")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                                    .padding(.top, 4)
+                            }
+                        case .keyCombo:
                             VStack(alignment: .leading, spacing: 8) {
                                 HStack {
                                     Text("Shortcut")
@@ -1176,7 +1232,7 @@ struct SettingsView: View {
                                 .padding(.vertical, 10)
                                 .background(Color(.textBackgroundColor).opacity(0.5))
                                 .cornerRadius(8)
-                                
+
                                 if isRecordingNewShortcut {
                                     Text("Press your new shortcut combination...")
                                         .foregroundColor(.secondary)

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -19,12 +19,13 @@ class ShortcutManager {
     private let holdThreshold: TimeInterval = 0.3
     private var holdMode = false
     private var useModifierOnlyHotkey = false
+    private var useMouseButtonHotkey = false
 
     private init() {
         print("ShortcutManager init")
-        
+
         setupKeyboardShortcuts()
-        setupModifierKeyMonitor()
+        setupRecordingTrigger()
         
         NotificationCenter.default.addObserver(
             self,
@@ -47,7 +48,7 @@ class ShortcutManager {
     }
     
     @objc private func hotkeySettingsChanged() {
-        setupModifierKeyMonitor()
+        setupRecordingTrigger()
     }
     
     private func setupKeyboardShortcuts() {
@@ -70,27 +71,49 @@ class ShortcutManager {
         KeyboardShortcuts.disable(.escape)
     }
     
-    private func setupModifierKeyMonitor() {
-        let modifierKeyString = AppPreferences.shared.modifierOnlyHotkey
-        let modifierKey = ModifierKey(rawValue: modifierKeyString) ?? .none
-        
-        if modifierKey != .none {
+    private func setupRecordingTrigger() {
+        let modifierKey = ModifierKey(rawValue: AppPreferences.shared.modifierOnlyHotkey) ?? .none
+        let mouseButton = MouseButton(rawValue: AppPreferences.shared.mouseButtonHotkey) ?? .none
+
+        // The three trigger modes are mutually exclusive. Tear all of them down
+        // first, then enable exactly one. A configured mouse button takes priority
+        // over a modifier key, which takes priority over the regular shortcut.
+        ModifierKeyMonitor.shared.stop()
+        MouseButtonMonitor.shared.stop()
+
+        if mouseButton != .none {
+            useMouseButtonHotkey = true
+            useModifierOnlyHotkey = false
+            KeyboardShortcuts.disable(.toggleRecord)
+
+            MouseButtonMonitor.shared.onButtonDown = { [weak self] in
+                self?.handleKeyDown()
+            }
+
+            MouseButtonMonitor.shared.onButtonUp = { [weak self] in
+                self?.handleKeyUp()
+            }
+
+            MouseButtonMonitor.shared.start(mouseButton: mouseButton)
+            print("ShortcutManager: Using mouse-button hotkey: \(mouseButton.displayName)")
+        } else if modifierKey != .none {
+            useMouseButtonHotkey = false
             useModifierOnlyHotkey = true
             KeyboardShortcuts.disable(.toggleRecord)
-            
+
             ModifierKeyMonitor.shared.onKeyDown = { [weak self] in
                 self?.handleKeyDown()
             }
-            
+
             ModifierKeyMonitor.shared.onKeyUp = { [weak self] in
                 self?.handleKeyUp()
             }
-            
+
             ModifierKeyMonitor.shared.start(modifierKey: modifierKey)
             print("ShortcutManager: Using modifier-only hotkey: \(modifierKey.displayName)")
         } else {
+            useMouseButtonHotkey = false
             useModifierOnlyHotkey = false
-            ModifierKeyMonitor.shared.stop()
             KeyboardShortcuts.enable(.toggleRecord)
             print("ShortcutManager: Using regular keyboard shortcut")
         }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -104,7 +104,10 @@ final class AppPreferences {
     
     @UserDefault(key: "modifierOnlyHotkey", defaultValue: "none")
     var modifierOnlyHotkey: String
-    
+
+    @UserDefault(key: "mouseButtonHotkey", defaultValue: "none")
+    var mouseButtonHotkey: String
+
     @UserDefault(key: "holdToRecord", defaultValue: true)
     var holdToRecord: Bool
     

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -1100,3 +1100,38 @@ final class TextUtilTests: XCTestCase {
         XCTAssertEqual(TextUtil.formatDuration(3600), "1h 0m 0s")
     }
 }
+
+final class MouseButtonTests: XCTestCase {
+
+    func testRawValueRoundTrips() {
+        for button in MouseButton.allCases {
+            XCTAssertEqual(MouseButton(rawValue: button.rawValue), button)
+        }
+    }
+
+    func testUnknownRawValueDefaultsToNil() {
+        XCTAssertNil(MouseButton(rawValue: "not-a-button"))
+    }
+
+    func testButtonNumberMapping() {
+        // macOS numbers buttons from zero: 2 = middle, 3+ = extra (thumb) buttons.
+        XCTAssertEqual(MouseButton.middle.buttonNumber, 2)
+        XCTAssertEqual(MouseButton.button4.buttonNumber, 3)
+        XCTAssertEqual(MouseButton.button5.buttonNumber, 4)
+        XCTAssertEqual(MouseButton.button6.buttonNumber, 5)
+    }
+
+    func testNoneIsNotAValidButtonNumber() {
+        XCTAssertEqual(MouseButton.none.buttonNumber, -1)
+    }
+
+    func testSelectableButtonsExcludeNone() {
+        let selectable = MouseButton.allCases.filter { $0 != .none }
+        XCTAssertFalse(selectable.contains(.none))
+        XCTAssertEqual(selectable.count, 4)
+        for button in selectable {
+            XCTAssertFalse(button.displayName.isEmpty)
+            XCTAssertFalse(button.shortSymbol.isEmpty)
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,8 @@ OpenSuperWhisper is a macOS application that provides real-time audio transcript
 - 🎙️ Real-time audio recording and transcription
 - 🧠 Two transcription engines: [Whisper](https://github.com/ggerganov/whisper.cpp) and [Parakeet](https://github.com/AntinomyCollective/FluidAudio) — download models directly from the app
 - ⌨️ Global keyboard shortcuts — key combination or single modifier key (e.g. Left ⌘, Right ⌥, Fn)
-- ✊ Hold-to-record mode — hold the shortcut to record, release to stop
+- 🖱️ Mouse button trigger — bind the middle or an extra (thumb) mouse button to start/stop recording
+- ✊ Hold-to-record mode — hold the shortcut, modifier key or mouse button to record, release to stop
 - 📁 Drag & drop audio files for transcription with queue processing
 - 🎤 Microphone selection — switch between built-in, external, Bluetooth and iPhone (Apple Continuity) mics from the menu bar
 - 🌍 Support for multiple languages with auto-detection


### PR DESCRIPTION
## Summary

Adds a third recording-trigger mode — **Mouse Button** — alongside the existing "Key Combination" and "Single Modifier Key" options in *Settings → Shortcuts → Recording Trigger*. Users can bind the middle button or an extra (thumb/side) button to toggle recording, and the existing **Hold to Record** behavior works with it too (hold to record, release to stop).

Closes #166.

## Motivation

The trigger could previously only be a keyboard shortcut or a single modifier key. Binding a spare mouse button is more ergonomic for hands-on-mouse dictation (requested in #166).

## How it works

This mirrors the existing `ModifierKeyMonitor` pattern so it slots into the current design with no behavior changes to the other modes:

- **`MouseButtonMonitor.swift`** *(new)* — a `CGEvent` tap on `.otherMouseDown` / `.otherMouseUp` that matches a chosen button via the `.mouseEventButtonNumber` field and drives `onButtonDown` / `onButtonUp`. It uses a **default (not listen-only) tap so the bound button is consumed** and acts purely as a recording trigger — no stray browser back/forward etc. Only the selected button is intercepted; every other click and keystroke passes straight through. The tap re-enables itself after a system timeout, exactly like the modifier monitor.
- **`ShortcutManager`** — `setupModifierKeyMonitor()` becomes `setupRecordingTrigger()`, which enables exactly one of the three mutually-exclusive modes (priority: mouse → modifier → key combination) and routes it into the existing `handleKeyDown` / `handleKeyUp`. Hold-to-record therefore works unchanged for all three.
- **`Settings`** — the trigger picker is now a 3-way segmented control; selecting a mode clears the others so they can't conflict. `MouseButton` offers Middle / Button 4 (Back) / Button 5 (Forward) / Button 6.
- **`AppPreferences`** — new `mouseButtonHotkey` preference (defaults to `"none"`, so existing users are unaffected).
- **`ContentView`** — the recording-hint symbol shows the mouse button when that mode is active.
- **`Readme.md`** — feature list updated.

No new entitlements: the app is already non-sandboxed with the accessibility (`.monitor` / `.control`) entitlements that `ModifierKeyMonitor` uses. As with single-modifier-key mode, this mode needs Accessibility / Input Monitoring permission to observe the button globally; the Settings panel notes this.

## Testing

- `./run.sh build` — builds clean (Xcode 26.4).
- Added `MouseButtonTests` (XCTest) covering the `MouseButton` raw-value round-trip and the `buttonNumber` mapping.
- The runtime path reuses the proven `ModifierKeyMonitor` mechanism (CGEvent session tap + `handleKeyDown`/`handleKeyUp`); I have not done a full interactive click-test in CI, so a quick hardware sanity check is welcome.

## Notes / open questions

- The bound button is **consumed** so it doesn't also fire its normal action. If you'd prefer it stay non-intercepting (listen-only, matching `ModifierKeyMonitor` exactly), that's a one-line change to `options:` — happy to switch.
- Kept the button list to middle + three extra buttons; easy to extend `MouseButton` if you want more.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fa9mx9KZhcnBbDQeXSuMZm
