### PR TITLE
unload whisper models to reduce RAM usage while idle

### DIFF
--- a/OpenSuperWhisper/Engines/WhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/WhisperEngine.swift
@@ -63,11 +63,14 @@ class WhisperEngine: TranscriptionEngine {
     }
     
     func initialize() async throws {
+        try loadModel()
+        unloadModel()
+    }
+    private func loadModel() throws {
         let modelPath = AppPreferences.shared.selectedWhisperModelPath ?? AppPreferences.shared.selectedModelPath
         guard let modelPath = modelPath else {
             throw TranscriptionError.contextInitializationFailed
         }
-        
         let params = WhisperContextParams()
         context = MyWhisperContext.initFromFile(path: modelPath, params: params)
         
@@ -75,8 +78,14 @@ class WhisperEngine: TranscriptionEngine {
             throw TranscriptionError.contextInitializationFailed
         }
     }
+    private func unloadModel(){
+        context = nil
+    }
     
     func transcribeAudio(url: URL, settings: Settings) async throws -> String {
+        try loadModel()
+        defer { unloadModel() }
+
         guard let context = context else {
             throw TranscriptionError.contextInitializationFailed
         }


### PR DESCRIPTION
## Summary

fixes #171 

This changes the Whisper engine so the model is loaded only when a transcription starts and unloaded after the transcription finishes.

## Testing

./run.sh build — builds clean
Ram usage is significantly reduced in the activity monitor (~1.5GB while idle to ~80MB)