### PR TITLE
fix(indicator): keep the recording indicator visible over full-screen apps

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -208,7 +208,7 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             )
             
             panel.isFloatingPanel = true
-            panel.level = .statusBar
+            panel.level = .screenSaver
             panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
             panel.backgroundColor = .clear
             panel.isOpaque = false


### PR DESCRIPTION
Hi @Starmel 👋

**What this does**

The recording indicator was invisible while dictating into an app in native full-screen. `.canJoinAllSpaces` + `.fullScreenAuxiliary` (from #172) let the panel join the full-screen space, but at `.statusBar` (25) it's still occluded by the full-screen app's system-elevated window. Raising the panel to `.screenSaver` — the level dedicated overlay apps (Lunar, notch apps) use to sit above full-screen content — fixes it, and it still clears the menu bar. One line, no behaviour change outside full-screen.

**Why we're opening this**

We're the My-Monkey collective — we've run a fork of OpenSuperWhisper for a while and built quite a bit on top of it (a Remote engine for any OpenAI-compatible server, Apple's on-device SpeechAnalyzer, a notch-style indicator, per-app model rules, and more). We noticed the base repo is active again, and honestly we'd much rather move forward *together* than maintain two projects that slowly drift apart.

This is a small, self-contained first step — a fix we shipped on our side that applies cleanly to yours. If you're open to it, we'd be glad to upstream more of what we've built, piece by piece, in whatever shape works for you. Just tell us what you'd welcome.

Thanks for the app 🙏🍌
