### PR TITLE
fix: only show green checkmark for the active engine's model

### DIFF
--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1536,18 +1536,22 @@ struct FluidAudioModelDownloadItemView: View {
     var isSelected: Bool {
         viewModel.fluidAudioModelVersion == model.version
     }
-    
+
+    var isActiveEngine: Bool {
+        viewModel.selectedEngine == "fluidaudio"
+    }
+
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
                 Text(model.name)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                
+
                 Text(model.description)
                     .font(.caption)
                     .foregroundColor(.secondary)
-                
+
                 if viewModel.isDownloading && viewModel.downloadingModelName == model.name {
                     ProgressView(value: model.downloadProgress)
                         .progressViewStyle(LinearProgressViewStyle())
@@ -1555,9 +1559,9 @@ struct FluidAudioModelDownloadItemView: View {
                         .padding(.top, 4)
                 }
             }
-            
+
             Spacer()
-            
+
             if viewModel.isDownloading && viewModel.downloadingModelName == model.name {
                 Button("Cancel") {
                     viewModel.cancelDownload()
@@ -1567,8 +1571,9 @@ struct FluidAudioModelDownloadItemView: View {
             } else if model.isDownloaded {
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(isActiveEngine ? .green : .secondary)
                         .imageScale(.large)
+                        .help(isActiveEngine ? "Active model" : "Selected, but Parakeet engine is not active")
                 } else {
                     Button(action: {
                         viewModel.fluidAudioModelVersion = model.version
@@ -1767,7 +1772,11 @@ struct ModelDownloadItemView: View {
         }
         return false
     }
-    
+
+    var isActiveEngine: Bool {
+        viewModel.selectedEngine == "whisper"
+    }
+
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
@@ -1808,8 +1817,9 @@ struct ModelDownloadItemView: View {
             } else if model.isDownloaded {
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(isActiveEngine ? .green : .secondary)
                         .imageScale(.large)
+                        .help(isActiveEngine ? "Active model" : "Selected, but Whisper engine is not active")
                 } else {
                     Button(action: {
                         let modelPath = WhisperModelManager.shared.modelsDirectory.appendingPathComponent(model.filename).path


### PR DESCRIPTION
## Summary
- Settings > Models showed a green checkmark on both the selected Whisper model row and the selected Parakeet/FluidAudio model row simultaneously, with no indication of which engine is actually active.
- Each row's checkmark now dims to secondary color when its engine (`selectedEngine`) isn't the one currently active, so only the truly active model's checkmark is green.

Fixes #139

## Test plan
- [ ] Download a Whisper model and a Parakeet model, switch the Engine picker between Whisper/Parakeet, and confirm only the active engine's model shows a green checkmark while the other shows a dimmed checkmark.