### PR TITLE
feat: add live transcription preview while recording

### DIFF
--- a/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/StreamingWhisperEngine.swift
@@ -1,0 +1,288 @@
+import AVFoundation
+import Foundation
+
+/// Live preview transcriber used only while recording is in progress. It taps
+/// the microphone with its own AVAudioEngine and runs a second, independent
+/// whisper context over a sliding window, so partial text can be shown in the
+/// indicator without touching the file-based batch pipeline that still produces
+/// the final inserted text. It is deliberately outside the TranscriptionEngine
+/// protocol: that protocol is URL/batch oriented, this one is push/streaming.
+final class StreamingWhisperEngine {
+    /// Emits (committed, pending) on the main queue. Committed text is stable and
+    /// only ever grows; pending is the tail of the window and is rewritten every
+    /// step. The consumer renders committed opaque and pending dimmed.
+    var onUpdate: (@MainActor (String, String) -> Void)?
+
+    /// Window/step geometry, mirroring examples/stream: decode a bounded window
+    /// whenever enough new audio has arrived, keep the newest
+    /// `commitDelaySeconds` as unstable (pending) and finalize anything older.
+    /// The step adapts to the hardware: it never goes below `minStepSeconds`,
+    /// and never below the previous decode's duration, so fast models update
+    /// several times a second while slow ones fall back to a coarser cadence
+    /// instead of piling up work. A slow preview never affects the final text.
+    private static let sampleRate: Double = 16000
+    private static let minStepSeconds: Double = 0.5
+    private static let commitDelaySeconds: Double = 1.5
+    private static let maxWindowSeconds: Double = 15.0
+
+    private let audioEngine = AVAudioEngine()
+    private var converter: AVAudioConverter?
+    private var targetFormat: AVAudioFormat?
+
+    /// Serial queue owning the whisper context and all accumulated audio: the
+    /// realtime tap only deep-copies its buffer and hands it off here, so whisper
+    /// never runs on the audio thread and the buffers need no extra locking.
+    private let processingQueue = DispatchQueue(label: "com.opensuperwhisper.streaming", qos: .userInitiated)
+
+    private var context: MyWhisperContext?
+    private let language: String?
+
+    // Owned by processingQueue only.
+    private var window: [Float] = []
+    private var samplesSinceStep = 0
+    private var lastDecodeSeconds: Double = 0
+    private var committedText = ""
+    private var isStopped = false
+
+    init() {
+        let lang = AppPreferences.shared.whisperLanguage
+        self.language = (lang == "auto" || lang.isEmpty) ? nil : lang
+    }
+
+    /// Loads a dedicated model context and starts tapping the microphone. Any
+    /// failure is reported through the return value; the caller keeps recording
+    /// regardless, since this is preview-only.
+    @discardableResult
+    func start() -> Bool {
+        guard let modelPath = AppPreferences.shared.selectedWhisperModelPath ?? AppPreferences.shared.selectedModelPath else {
+            return false
+        }
+
+        let params = WhisperContextParams()
+        guard let ctx = MyWhisperContext.initFromFile(path: modelPath, params: params) else {
+            return false
+        }
+        context = ctx
+
+        let inputNode = audioEngine.inputNode
+        let inputFormat = inputNode.inputFormat(forBus: 0)
+        guard inputFormat.sampleRate > 0,
+              let target = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Self.sampleRate, channels: 1, interleaved: false),
+              let conv = AVAudioConverter(from: inputFormat, to: target) else {
+            context = nil
+            return false
+        }
+        targetFormat = target
+        converter = conv
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            self?.handleTap(buffer)
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            return true
+        } catch {
+            print("StreamingWhisperEngine failed to start audio engine: \(error)")
+            inputNode.removeTap(onBus: 0)
+            context = nil
+            return false
+        }
+    }
+
+    func stop() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        processingQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.isStopped = true
+            self.context = nil
+            self.window = []
+        }
+    }
+
+    // MARK: - Audio capture
+
+    private func handleTap(_ buffer: AVAudioPCMBuffer) {
+        // The tap buffer is only valid for the duration of this callback, so a
+        // deep copy is handed to the processing queue; nothing heavy runs here.
+        guard let copy = Self.copyBuffer(buffer) else { return }
+        processingQueue.async { [weak self] in
+            self?.ingest(copy)
+        }
+    }
+
+    private static func copyBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: buffer.frameLength) else {
+            return nil
+        }
+        copy.frameLength = buffer.frameLength
+        let channels = Int(buffer.format.channelCount)
+        let frames = Int(buffer.frameLength)
+        if let src = buffer.floatChannelData, let dst = copy.floatChannelData {
+            for ch in 0..<channels {
+                dst[ch].update(from: src[ch], count: frames)
+            }
+        } else if let src = buffer.int16ChannelData, let dst = copy.int16ChannelData {
+            for ch in 0..<channels {
+                dst[ch].update(from: src[ch], count: frames)
+            }
+        } else {
+            return nil
+        }
+        return copy
+    }
+
+    private func ingest(_ buffer: AVAudioPCMBuffer) {
+        guard !isStopped, let converter = converter, let targetFormat = targetFormat else { return }
+
+        let ratio = Self.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 256
+        guard let out = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return }
+
+        var consumed = false
+        var convError: NSError?
+        converter.convert(to: out, error: &convError) { _, status in
+            if consumed {
+                status.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            status.pointee = .haveData
+            return buffer
+        }
+        if convError != nil { return }
+
+        let frames = Int(out.frameLength)
+        guard frames > 0, let channel = out.floatChannelData?[0] else { return }
+        window.append(contentsOf: UnsafeBufferPointer(start: channel, count: frames))
+        samplesSinceStep += frames
+
+        let stepSeconds = max(Self.minStepSeconds, lastDecodeSeconds)
+        if samplesSinceStep >= Int(stepSeconds * Self.sampleRate) {
+            samplesSinceStep = 0
+            runStep()
+        }
+    }
+
+    // MARK: - Inference
+
+    private func runStep() {
+        guard !isStopped, let context = context, !window.isEmpty else { return }
+
+        var params = WhisperFullParams()
+        params.strategy = .greedy
+        params.nThreads = Int32(max(2, min(ProcessInfo.processInfo.activeProcessorCount, 8)))
+        params.noContext = true
+        params.noTimestamps = false
+        params.singleSegment = false
+        params.printProgress = false
+        params.printRealtime = false
+        params.printTimestamps = false
+        params.printSpecial = false
+        params.suppressBlank = true
+        params.temperature = 0.0
+        params.language = language
+        params.detectLanguage = false
+
+        var cParams = params.toC()
+        let decodeStart = CFAbsoluteTimeGetCurrent()
+        guard context.full(samples: window, params: &cParams) else { return }
+        lastDecodeSeconds = CFAbsoluteTimeGetCurrent() - decodeStart
+
+        let windowDuration = Double(window.count) / Self.sampleRate
+        let commitBoundary = windowDuration - Self.commitDelaySeconds
+
+        var committedThisStep = ""
+        var pending = ""
+        var commitUpToSeconds = 0.0
+
+        let nSegments = context.fullNSegments
+        for i in 0..<nSegments {
+            guard let raw = context.fullGetSegmentText(iSegment: i) else { continue }
+            let text = Self.clean(raw)
+            let segEnd = Double(context.fullGetSegmentT1(iSegment: i)) / 100.0
+
+            // Finalize a segment once its end is comfortably in the past.
+            if segEnd <= commitBoundary {
+                if !text.isEmpty {
+                    committedThisStep = Self.joined(committedThisStep, text)
+                }
+                commitUpToSeconds = segEnd
+            } else if !text.isEmpty {
+                pending = Self.joined(pending, text)
+            }
+        }
+
+        if !committedThisStep.isEmpty {
+            committedText = Self.joined(committedText, committedThisStep)
+        }
+
+        // Drop the committed prefix from the window so it is not decoded again.
+        if commitUpToSeconds > 0 {
+            let dropCount = min(Int(commitUpToSeconds * Self.sampleRate), window.count)
+            if dropCount > 0 {
+                window.removeFirst(dropCount)
+            }
+        }
+
+        // Continuous speech can yield a single segment spanning the whole window,
+        // whose end never crosses the commit boundary; without a fallback the
+        // window would grow without bound and each decode would take longer.
+        // The whole window has been decoded at this point (ingest and decode share
+        // one serial queue), so folding the pending tail into the committed text
+        // and starting a fresh window loses nothing and cannot duplicate output.
+        if window.count > Int(Self.maxWindowSeconds * Self.sampleRate) {
+            if !pending.isEmpty {
+                committedText = Self.joined(committedText, pending)
+                pending = ""
+            }
+            window = []
+        }
+
+        let committedSnapshot = committedText
+        let pendingSnapshot = pending
+        if let onUpdate = onUpdate {
+            Task { @MainActor in
+                onUpdate(committedSnapshot, pendingSnapshot)
+            }
+        }
+    }
+
+    private static func clean(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "[MUSIC]", with: "")
+            .replacingOccurrences(of: "[BLANK_AUDIO]", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Joins two transcript fragments with a space, except at CJK boundaries:
+    /// there the fragments are parts of one unspaced sentence and inserting a
+    /// space would corrupt the text. Never modifies `head`, so joined output
+    /// only ever grows by a suffix — the streaming input delta logic relies on
+    /// that.
+    static func joined(_ head: String, _ tail: String) -> String {
+        guard !head.isEmpty else { return tail }
+        guard !tail.isEmpty else { return head }
+        if isCJK(head.last!) || isCJK(tail.first!) {
+            return head + tail
+        }
+        return head + " " + tail
+    }
+
+    private static func isCJK(_ character: Character) -> Bool {
+        guard let scalar = character.unicodeScalars.first else { return false }
+        switch scalar.value {
+        case 0x3000...0x30FF,  // CJK punctuation, hiragana, katakana
+             0x3400...0x9FFF,  // CJK unified ideographs
+             0xF900...0xFAFF,  // CJK compatibility ideographs
+             0xFF00...0xFF9F:  // full-width forms, half-width katakana
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -26,7 +26,19 @@ class IndicatorViewModel: ObservableObject {
     @Published var isBlinking = false
     @Published var isConfirmingCancel = false
     @Published var recorder: AudioRecorder = .shared
-    
+
+    /// Live preview shown while recording. `liveCommitted` is stable text,
+    /// `livePending` is the still-changing tail. Empty unless the live streaming
+    /// preview is enabled and producing output.
+    @Published var liveCommitted = ""
+    @Published var livePending = ""
+
+    var hasLivePreview: Bool {
+        !liveCommitted.isEmpty || !livePending.isEmpty
+    }
+
+    private var streamingEngine: StreamingWhisperEngine?
+
     var recordingStartedAt: Date?
     
     var delegate: IndicatorViewDelegate?
@@ -107,8 +119,36 @@ class IndicatorViewModel: ObservableObject {
         state = .recording
         startBlinking()
         recordingStartedAt = Date()
-        
+
         recorder.startRecording()
+        startLivePreview()
+    }
+
+    /// Starts the optional live preview alongside recording. Whisper engine only;
+    /// any failure is logged and ignored so the recording itself is never affected.
+    private func startLivePreview() {
+        guard AppPreferences.shared.liveStreamingPreview,
+              AppPreferences.shared.selectedEngine == "whisper" else { return }
+
+        liveCommitted = ""
+        livePending = ""
+
+        let engine = StreamingWhisperEngine()
+        engine.onUpdate = { [weak self] committed, pending in
+            guard let self = self, self.state == .recording else { return }
+            self.liveCommitted = committed
+            self.livePending = pending
+        }
+        if engine.start() {
+            streamingEngine = engine
+        }
+    }
+
+    private func stopLivePreview() {
+        streamingEngine?.stop()
+        streamingEngine = nil
+        liveCommitted = ""
+        livePending = ""
     }
     
     func handleCancelRequest() -> Bool {
@@ -141,9 +181,10 @@ class IndicatorViewModel: ObservableObject {
         // A second stop request (double hotkey press, hold-mode key-up) must not
         // restart decoding or hide the window while transcription is in flight.
         guard state == .recording || state == .connecting else { return }
-        
+
         resetCancelConfirmation()
         stopBlinking()
+        stopLivePreview()
         
         if isTranscriptionBusy {
             // The engine is busy with another transcription: keep the user's audio
@@ -263,6 +304,7 @@ class IndicatorViewModel: ObservableObject {
 
     func cleanup() {
         stopBlinking()
+        stopLivePreview()
         resetCancelConfirmation()
         recordingStartedAt = nil
         hideTimer?.invalidate()
@@ -273,6 +315,7 @@ class IndicatorViewModel: ObservableObject {
     func cancelRecording() {
         hideTimer?.invalidate()
         hideTimer = nil
+        stopLivePreview()
         recorder.cancelRecording()
     }
 }
@@ -296,6 +339,29 @@ struct RecordingIndicator: View {
             .shadow(color: .red.opacity(0.5), radius: 4)
             .opacity(isBlinking ? 0.3 : 1.0)
             .animation(.easeInOut(duration: 0.4), value: isBlinking)
+    }
+}
+
+struct LiveTextView: View {
+    let committed: String
+    let pending: String
+
+    private var text: Text {
+        let committedText = Text(committed)
+            .foregroundColor(.primary)
+        guard !pending.isEmpty else { return committedText }
+        let separator = committed.isEmpty ? "" : " "
+        return committedText + Text(separator + pending).foregroundColor(.secondary)
+    }
+
+    var body: some View {
+        text
+            .font(.system(size: 11))
+            .lineLimit(2)
+            // Keep the newest words visible: the tail is what the user just said.
+            .truncationMode(.head)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -326,6 +392,9 @@ struct IndicatorWindow: View {
     /// so the appear offset (moves the card down) and the spring overshoot
     /// need margins, otherwise the card edges are visibly clipped mid-animation.
     static let cardSize = CGSize(width: 200, height: 36)
+    /// Taller card used when the live preview is visible. Kept small enough that
+    /// the card still fits inside the fixed panel (windowSize) without clipping.
+    static let expandedCardHeight: CGFloat = 76
     static let windowSize = CGSize(width: 256, height: 96)
     static let appearOffset: CGFloat = 20
     static let appearInitialScale: CGFloat = 0.5
@@ -357,19 +426,25 @@ struct IndicatorWindow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
             case .recording:
-                HStack(spacing: 8) {
-                    RecordingIndicator(isBlinking: viewModel.isBlinking)
-                        .frame(width: 24)
-                    
-                    if viewModel.isConfirmingCancel {
-                        Text("Press Esc to cancel")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(.orange)
-                            .transition(.opacity)
-                    } else {
-                        Text("Recording...")
-                            .font(.system(size: 13, weight: .semibold))
-                            .transition(.opacity)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        RecordingIndicator(isBlinking: viewModel.isBlinking)
+                            .frame(width: 24)
+
+                        if viewModel.isConfirmingCancel {
+                            Text("Press Esc to cancel")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundColor(.orange)
+                                .transition(.opacity)
+                        } else {
+                            Text("Recording...")
+                                .font(.system(size: 13, weight: .semibold))
+                                .transition(.opacity)
+                        }
+                    }
+
+                    if viewModel.hasLivePreview && !viewModel.isConfirmingCancel {
+                        LiveTextView(committed: viewModel.liveCommitted, pending: viewModel.livePending)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -415,7 +490,9 @@ struct IndicatorWindow: View {
             }
         }
         .padding(.horizontal, 24)
-        .frame(height: Self.cardSize.height)
+        // Grows to fit the two-line live preview while staying inside the panel,
+        // so the card is not clipped and needs no window repositioning.
+        .frame(height: viewModel.hasLivePreview && viewModel.state == .recording ? Self.expandedCardHeight : Self.cardSize.height)
         .background {
             rect
                 .fill(backgroundColor)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -93,6 +93,12 @@ class SettingsViewModel: ObservableObject {
             AppPreferences.shared.showTimestamps = showTimestamps
         }
     }
+
+    @Published var liveStreamingPreview: Bool {
+        didSet {
+            AppPreferences.shared.liveStreamingPreview = liveStreamingPreview
+        }
+    }
     
     @Published var temperature: Double {
         didSet {
@@ -209,6 +215,7 @@ class SettingsViewModel: ObservableObject {
         self.selectedLanguage = prefs.whisperLanguage
         self.suppressBlankAudio = prefs.suppressBlankAudio
         self.showTimestamps = prefs.showTimestamps
+        self.liveStreamingPreview = prefs.liveStreamingPreview
         self.temperature = prefs.temperature
         self.noSpeechThreshold = prefs.noSpeechThreshold
         self.initialPrompt = prefs.initialPrompt
@@ -944,6 +951,22 @@ struct SettingsView: View {
                             Toggle("", isOn: $viewModel.addSpaceAfterSentence)
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
                                 .labelsHidden()
+                        }
+
+                        if viewModel.selectedEngine == "whisper" {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Live Preview While Recording")
+                                        .font(.subheadline)
+                                    Text("Shows partial text in the indicator as you speak. The inserted text still comes from the final transcription.")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                Toggle("", isOn: $viewModel.liveStreamingPreview)
+                                    .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                    .labelsHidden()
+                            }
                         }
                     }
                 }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -83,6 +83,12 @@ final class AppPreferences {
     
     @UserDefault(key: "useBeamSearch", defaultValue: false)
     var useBeamSearch: Bool
+
+    /// When enabled (Whisper engine only), the indicator shows a live sliding-window
+    /// preview while recording. The final inserted text still comes from the
+    /// post-recording batch transcription, so this only affects what is displayed.
+    @UserDefault(key: "liveStreamingPreview", defaultValue: false)
+    var liveStreamingPreview: Bool
     
     @UserDefault(key: "beamSize", defaultValue: 5)
     var beamSize: Int


### PR DESCRIPTION
## What

Adds an optional **live partial-text preview** in the recording indicator, using **stock whisper.cpp only** (no submodule/fork changes). While you speak, the indicator shows the transcript building up in real time; the text that actually gets inserted is still produced by the existing post-recording batch pipeline, so the final output is unchanged.

Implements #185.

This is **opt-in** and off by default: *Settings → Live Preview While Recording* (shown for the Whisper engine only).

## How

The preview runs a second, independent whisper context over a sliding window while recording, entirely separate from the file-based batch transcription that produces the final text. This keeps the diff and the risk contained — a slow or wrong preview can never affect the inserted result.

- **New `StreamingWhisperEngine`** (`OpenSuperWhisper/Engines/StreamingWhisperEngine.swift`): its own `AVAudioEngine` tap → deep-copied buffers handed to a serial queue → `AVAudioConverter` to 16 kHz mono Float32 → repeated `whisper_full` over a bounded window, mirroring the `examples/stream` pattern (`single_segment=false`, `no_context=true`). The dedicated context is loaded only while recording and freed on stop.
- **Committed vs. pending split**: segments whose end is older than a 1.5 s commit boundary are finalized (rendered opaque); the newest tail is shown dimmed and rewritten each step, which absorbs the flicker inherent to re-decoding a growing window.
- **Adaptive decode cadence**: a step is triggered once enough new audio has arrived, never below 0.5 s and never below the previous decode's wall-clock duration. Fast models update several times a second; slow ones fall back to a coarser cadence instead of piling up work.
- **Bounded window**: continuous speech can yield one segment spanning the whole window whose end never crosses the commit boundary. A hard 15 s cap folds the pending tail into committed text and resets the window — safe because ingest and decode share one serial queue, so the whole window has already been decoded at that point.
- **CJK-aware joining**: no space is inserted at Japanese/Chinese/Korean boundaries, where fragments are parts of one unspaced sentence.

The indicator (`IndicatorWindow.swift`) gains a two-tone live text view (committed opaque + pending dimmed) and grows to fit while a preview is active.

## How was this tested

- Built and run locally on Apple Silicon (ad-hoc signed dev build).
- Verified live preview end-to-end with Japanese speech using a `ggml-small` model: partial text appears and updates while speaking, and the final inserted text matches the existing batch result.
- Confirmed the feature is inert when the toggle is off and when a non-Whisper engine is selected.
- No changes to the whisper.cpp submodule; the submodule pointer is untouched.

Not benchmarked with large models yet — on slower hardware the adaptive cadence trades update frequency for stability rather than blocking, but I have not profiled memory/CPU under `large-v3`. Happy to add numbers if useful.

## Note on #147

#147 pipelines decoding via a forked whisper.cpp but does not surface live text (the indicator stays "Recording..."). This PR is complementary and stays on stock whisper.cpp. If you'd prefer to land #147 first, I'm happy to rebase this preview layer on top of it.
