### PR TITLE
feat: add a rebindable hotkey to paste the most recent transcription

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -215,33 +215,13 @@ class IndicatorViewModel: ObservableObject {
     }
     
     func insertText(_ text: String) {
-        guard !text.isEmpty else { return }
-        let finalText = Self.applyPostProcessing(text)
-        let prefs = AppPreferences.shared
-
-        if prefs.autoPasteTranscription {
-            if prefs.autoCopyToClipboard {
-                // Paste and keep in clipboard
-                ClipboardUtil.insertTextAndKeepInClipboard(finalText)
-            } else {
-                // Paste but restore original clipboard (legacy behavior)
-                ClipboardUtil.insertText(finalText)
-            }
-        } else if prefs.autoCopyToClipboard {
-            // Only copy to clipboard, don't paste
-            ClipboardUtil.copyToClipboard(finalText)
-        }
-        // If both are false, do nothing
-
+        TranscriptionInserter.insert(text)
     }
-    
+
+    /// Retained as the canonical symbol for existing tests; the implementation
+    /// now lives in `TranscriptionInserter`.
     static func applyPostProcessing(_ text: String) -> String {
-        guard AppPreferences.shared.addSpaceAfterSentence,
-              let lastChar = text.last,
-              lastChar.isPunctuation else {
-            return text
-        }
-        return text + " "
+        TranscriptionInserter.applyPostProcessing(text)
     }
     
     private func startBlinking() {

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -177,6 +177,42 @@ class RecordingStore: ObservableObject {
         }
     }
 
+    /// Which transcription the paste-last-transcription hotkey should use:
+    /// the newest completed recording that actually has text.
+    ///
+    /// Pure and separately testable; `getLastPasteableRecording()` applies it
+    /// to rows read from the database. Keeping the rule here rather than in
+    /// SQL means there is exactly one definition of "pasteable".
+    ///
+    /// `nonisolated` so plain `XCTestCase` classes can call it, matching
+    /// `retentionCutoffDate` and `isDeletableRecordingURL` below.
+    nonisolated static func lastPasteable(from recordings: [Recording]) -> Recording? {
+        recordings
+            .filter { $0.status == .completed }
+            .filter { !$0.transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .max { $0.timestamp < $1.timestamp }
+    }
+
+    /// The newest completed, non-empty transcription, or nil when there is none.
+    func getLastPasteableRecording() -> Recording? {
+        do {
+            let candidates = try dbQueue.read { db in
+                // Narrow in SQL, then apply the full rule in Swift. The limit is
+                // a safety bound so a run of blank-but-completed rows cannot
+                // force a full-table read.
+                try Recording
+                    .filter(Recording.Columns.status == RecordingStatus.completed.rawValue)
+                    .order(Recording.Columns.timestamp.desc)
+                    .limit(20)
+                    .fetchAll(db)
+            }
+            return Self.lastPasteable(from: candidates)
+        } catch {
+            print("Failed to fetch last pasteable recording: \(error)")
+            return nil
+        }
+    }
+
     static let recordingsDidUpdateNotification = Notification.Name("RecordingStore.recordingsDidUpdate")
 
     func addRecording(_ recording: Recording) {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1344,7 +1344,36 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color(.controlBackgroundColor).opacity(0.3))
                 .cornerRadius(12)
-                
+
+                // Paste Last Transcription
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Paste Last Transcription")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Shortcut")
+                                .font(.subheadline)
+                            Spacer()
+                            KeyboardShortcuts.Recorder("", name: .pasteLastTranscription)
+                                .frame(width: 150)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color(.textBackgroundColor).opacity(0.5))
+                        .cornerRadius(8)
+
+                        Text("Pastes your most recent transcription at the cursor. Useful when the cursor wasn't where you wanted it when the recording finished.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
                 // Recording Behavior
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Recording Behavior")

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -9,6 +9,8 @@ import SwiftUI
 extension KeyboardShortcuts.Name {
     static let toggleRecord = Self("toggleRecord", default: .init(.backtick, modifiers: .option))
     static let escape = Self("escape", default: .init(.escape))
+    static let pasteLastTranscription = Self("pasteLastTranscription",
+                                             default: .init(.v, modifiers: [.command, .control]))
 }
 
 class ShortcutManager {
@@ -70,8 +72,29 @@ class ShortcutManager {
             }
         }
         KeyboardShortcuts.disable(.escape)
+
+        // Key-up rather than key-down, matching .escape above, so the
+        // synthesized Cmd+V cannot race the user's own modifier keys still
+        // being physically held down.
+        KeyboardShortcuts.onKeyUp(for: .pasteLastTranscription) {
+            Task { @MainActor in
+                Self.pasteLastTranscription()
+            }
+        }
     }
     
+    /// Pastes the most recent transcription at the current cursor position.
+    /// Always pastes, even when automatic pasting is disabled — an explicit
+    /// keypress is an explicit request.
+    @MainActor
+    static func pasteLastTranscription() {
+        guard let recording = RecordingStore.shared.getLastPasteableRecording() else {
+            print("Paste last transcription: no transcription available")
+            return
+        }
+        TranscriptionInserter.insert(recording.transcription, forcePaste: true)
+    }
+
     private func setupRecordingTrigger() {
         let modifierKey = ModifierKey(rawValue: AppPreferences.shared.modifierOnlyHotkey) ?? .none
         let mouseButton = MouseButton(rawValue: AppPreferences.shared.mouseButtonHotkey) ?? .none

--- a/OpenSuperWhisper/Utils/TranscriptionInserter.swift
+++ b/OpenSuperWhisper/Utils/TranscriptionInserter.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// How a transcription should reach the user's cursor and clipboard.
+enum InsertionAction: Equatable {
+    /// Paste, and leave the transcription on the clipboard.
+    case pasteKeepingClipboard
+    /// Paste, and restore the user's previous clipboard afterwards.
+    case pasteRestoringClipboard
+    /// Copy to the clipboard without pasting.
+    case copyOnly
+    /// Do nothing. Named `doNothing` rather than `none` so it can never be
+    /// confused with `Optional.none` at a call site.
+    case doNothing
+}
+
+/// The single entry point for putting a transcription in front of the user.
+/// Both the record-time path and the paste-last-transcription hotkey route
+/// through here so their behavior can never drift apart.
+@MainActor
+enum TranscriptionInserter {
+
+    /// Pure routing rule.
+    ///
+    /// `forcePaste` is used by the explicit paste-last-transcription hotkey:
+    /// an on-demand request to paste should paste even when the user has
+    /// turned automatic pasting off, because pasting is the entire point of
+    /// pressing it.
+    ///
+    /// `nonisolated` so plain `XCTestCase` classes can exercise it directly,
+    /// matching `RecordingStore.retentionCutoffDate`.
+    nonisolated static func action(autoPaste: Bool, autoCopy: Bool, forcePaste: Bool) -> InsertionAction {
+        if autoPaste || forcePaste {
+            return autoCopy ? .pasteKeepingClipboard : .pasteRestoringClipboard
+        }
+        return autoCopy ? .copyOnly : .doNothing
+    }
+
+    /// Appends a trailing space after terminal punctuation when the user has
+    /// that preference enabled.
+    static func applyPostProcessing(_ text: String) -> String {
+        guard AppPreferences.shared.addSpaceAfterSentence,
+              let lastChar = text.last,
+              lastChar.isPunctuation else {
+            return text
+        }
+        return text + " "
+    }
+
+    static func insert(_ text: String, forcePaste: Bool = false) {
+        guard !text.isEmpty else { return }
+
+        let finalText = applyPostProcessing(text)
+        let prefs = AppPreferences.shared
+
+        switch action(autoPaste: prefs.autoPasteTranscription,
+                      autoCopy: prefs.autoCopyToClipboard,
+                      forcePaste: forcePaste) {
+        case .pasteKeepingClipboard:
+            ClipboardUtil.insertTextAndKeepInClipboard(finalText)
+        case .pasteRestoringClipboard:
+            ClipboardUtil.insertText(finalText)
+        case .copyOnly:
+            ClipboardUtil.copyToClipboard(finalText)
+        case .doNothing:
+            break
+        }
+    }
+}

--- a/OpenSuperWhisperTests/LastPasteableRecordingTests.swift
+++ b/OpenSuperWhisperTests/LastPasteableRecordingTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+final class LastPasteableRecordingTests: XCTestCase {
+
+    private func makeRecording(_ transcription: String,
+                               status: RecordingStatus = .completed,
+                               secondsAgo: TimeInterval) -> Recording {
+        Recording(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000 - secondsAgo),
+            fileName: "\(UUID().uuidString).wav",
+            transcription: transcription,
+            duration: 1.0,
+            status: status,
+            progress: 1.0,
+            sourceFileURL: nil
+        )
+    }
+
+    func testLastPasteable_emptyInput_returnsNil() {
+        XCTAssertNil(RecordingStore.lastPasteable(from: []))
+    }
+
+    func testLastPasteable_picksMostRecent() throws {
+        let recordings = [
+            makeRecording("older", secondsAgo: 100),
+            makeRecording("newest", secondsAgo: 10),
+            makeRecording("oldest", secondsAgo: 500),
+        ]
+        let result = try XCTUnwrap(RecordingStore.lastPasteable(from: recordings))
+        XCTAssertEqual(result.transcription, "newest")
+    }
+
+    func testLastPasteable_ignoresIncompleteStatuses() throws {
+        let recordings = [
+            makeRecording("done", secondsAgo: 100),
+            makeRecording("in flight", status: .transcribing, secondsAgo: 10),
+            makeRecording("queued", status: .pending, secondsAgo: 5),
+            makeRecording("broken", status: .failed, secondsAgo: 1),
+        ]
+        let result = try XCTUnwrap(RecordingStore.lastPasteable(from: recordings))
+        XCTAssertEqual(result.transcription, "done")
+    }
+
+    func testLastPasteable_ignoresEmptyAndWhitespaceOnly() throws {
+        let recordings = [
+            makeRecording("real text", secondsAgo: 100),
+            makeRecording("", secondsAgo: 20),
+            makeRecording("   \n\t ", secondsAgo: 10),
+        ]
+        let result = try XCTUnwrap(RecordingStore.lastPasteable(from: recordings))
+        XCTAssertEqual(result.transcription, "real text")
+    }
+
+    func testLastPasteable_noUsableCandidates_returnsNil() {
+        let recordings = [
+            makeRecording("", secondsAgo: 20),
+            makeRecording("pending text", status: .pending, secondsAgo: 10),
+        ]
+        XCTAssertNil(RecordingStore.lastPasteable(from: recordings))
+    }
+
+    // The rule must not depend on the caller having pre-sorted the array.
+    func testLastPasteable_doesNotRelyOnInputOrdering() throws {
+        let ascending = [
+            makeRecording("oldest", secondsAgo: 500),
+            makeRecording("newest", secondsAgo: 10),
+        ]
+        let descending: [Recording] = ascending.reversed()
+
+        XCTAssertEqual(try XCTUnwrap(RecordingStore.lastPasteable(from: ascending)).transcription, "newest")
+        XCTAssertEqual(try XCTUnwrap(RecordingStore.lastPasteable(from: descending)).transcription, "newest")
+    }
+}

--- a/OpenSuperWhisperTests/TranscriptionInserterTests.swift
+++ b/OpenSuperWhisperTests/TranscriptionInserterTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+final class TranscriptionInserterActionTests: XCTestCase {
+
+    func testAction_autoPasteAndAutoCopy_pastesKeepingClipboard() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: true, autoCopy: true, forcePaste: false),
+            .pasteKeepingClipboard)
+    }
+
+    func testAction_autoPasteOnly_pastesRestoringClipboard() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: true, autoCopy: false, forcePaste: false),
+            .pasteRestoringClipboard)
+    }
+
+    func testAction_autoCopyOnly_copiesWithoutPasting() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: true, forcePaste: false),
+            .copyOnly)
+    }
+
+    func testAction_neitherEnabled_doesNothing() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: false, forcePaste: false),
+            .doNothing)
+    }
+
+    // forcePaste is the hotkey's contract: an explicit request always pastes,
+    // even for a user who has turned automatic pasting off.
+    func testAction_forcePaste_overridesDisabledAutoPaste() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: false, forcePaste: true),
+            .pasteRestoringClipboard)
+    }
+
+    func testAction_forcePaste_respectsKeepInClipboard() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: true, forcePaste: true),
+            .pasteKeepingClipboard)
+    }
+
+    func testAction_forcePaste_withAutoPasteAlreadyOn_isUnchanged() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: true, autoCopy: false, forcePaste: true),
+            .pasteRestoringClipboard)
+    }
+}


### PR DESCRIPTION
## Why

When a recording finishes, the transcription is pasted wherever the cursor happens to be. That's usually right, but not always — you tab away mid-dictation, the focused field wasn't the one you meant, or the paste lands somewhere unhelpful. Today the only recovery is opening the app and copying the text out of the history list by hand.

This adds a rebindable shortcut that pastes your most recent transcription on demand.

## What

- New `KeyboardShortcuts.Name.pasteLastTranscription`, default <kbd>⌘</kbd><kbd>⌃</kbd><kbd>V</kbd>, rebindable from Settings via the existing `KeyboardShortcuts.Recorder`.
- Pressing it pastes the newest completed, non-empty transcription at the cursor.
- Stateless by design: repeated presses paste the same text rather than walking backwards through history. Older transcriptions stay reachable through the app window.

## How

`IndicatorViewModel.insertText` owned the branching between `insertTextAndKeepInClipboard` / `insertText` / `copyToClipboard`. Rather than duplicate that, it's extracted into `TranscriptionInserter`, which both the record-time path and the new hotkey call. The clipboard strategy therefore can't drift between them, and the hotkey inherits any future clipboard fixes for free.

Selection is `RecordingStore.lastPasteable(from:)` — a `nonisolated static` pure function, matching the convention already used by `retentionCutoffDate` and `isDeletableRecordingURL`, so it's testable without touching the database.

One detail worth naming: `RecordingStore` persists the **raw** transcription, and post-processing (the trailing space after punctuation) is applied at paste time. The hotkey path applies the same post-processing, so its output is identical to a normal paste rather than subtly different.

## Two decisions I'd like your call on

**1. Default binding.** <kbd>⌘</kbd><kbd>⌃</kbd><kbd>V</kbd> isn't claimed by macOS, but it could collide with a user's existing binding. Happy to ship it unbound instead — one-line change.

**2. It pastes even when "Automatically paste transcription" is off.** My reasoning: that preference governs *automatic* behavior, and an explicit keypress named "paste last transcription" should paste. But it's a judgment call, and the opposite reading is defensible. The behavior is isolated in `TranscriptionInserter.action(autoPaste:autoCopy:forcePaste:)`, so flipping it is trivial.

## Tests

13 new unit tests, all passing:

- `TranscriptionInserterActionTests` — 7 tests covering every combination of the two preferences plus the force-paste override.
- `LastPasteableRecordingTests` — 6 tests for the selection rule: newest wins, incomplete statuses excluded, empty and whitespace-only excluded, ordering-independent.

The 14 existing `applyPostProcessing` tests still pass unchanged, which is the regression gate for the refactor — `IndicatorViewModel.applyPostProcessing` is retained as the canonical symbol and forwards to the new implementation.

## Test plan

- [x] Dictate, click into a different field, press ⌘⌃V → the transcription pastes
- [x] Press again → same text pastes again
- [x] Turn off auto-paste, dictate, press ⌘⌃V → still pastes
- [x] Rebind the shortcut in Settings → new binding takes effect immediately
- [x] No history → no-op, no crash
- [x] Section stays visible in all three trigger modes (key combo, modifier key, mouse button)

That last one is why the Settings row sits outside the trigger-mode `switch` — the existing shortcut recorder is nested inside `case .keyCombo` and disappears in the other two modes. This shortcut works in every mode, so it shouldn't vanish with them.

## Note

Tested against `master`, not `0.1.0` — the clipboard fixes on master aren't in the last release yet (see #170).
