### PR TITLE
fix: allow the main window to be resized horizontally

### DIFF
--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -29,7 +29,7 @@ struct OpenSuperWhisperApp: App {
                     ContentView()
                 }
             }
-            .frame(width: 450)
+            .frame(minWidth: 450)
             .frame(minHeight: 400, maxHeight: 900)
             .environmentObject(appState)
         }

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -397,11 +397,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         adoptMainWindow(window)
     }
 
+    /// Applies the main window's resize limits.
+    ///
+    /// Width is deliberately unbounded: it was previously pinned to the same
+    /// 450pt as the minimum, which made AppKit refuse horizontal resizing
+    /// regardless of what the SwiftUI content declared. The height range is
+    /// pre-existing intentional behavior and is unchanged.
+    static func applyMainWindowSizeLimits(to window: NSWindow) {
+        window.minSize = NSSize(width: 450, height: 400)
+        window.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: 900)
+    }
+
     private func adoptMainWindow(_ window: NSWindow) {
         mainWindow = window
         window.delegate = self
-        window.minSize = NSSize(width: 450, height: 400)
-        window.maxSize = NSSize(width: 450, height: 900)
+        Self.applyMainWindowSizeLimits(to: window)
 
         if hideMainWindowAtLaunch {
             hideMainWindowAtLaunch = false
@@ -445,6 +455,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
 extension AppDelegate: NSWindowDelegate {
     func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
-        return NSSize(width: 450, height: frameSize.height)
+        // This previously rewrote width to a fixed 450, which made horizontal
+        // resizing impossible: AppKit consults the delegate on every resize, so
+        // the returned size wins over the window's own minSize/maxSize. Honor
+        // the drag and let those limits do their job instead.
+        return frameSize
     }
 }

--- a/OpenSuperWhisperTests/MainWindowResizabilityTests.swift
+++ b/OpenSuperWhisperTests/MainWindowResizabilityTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import XCTest
+@testable import OpenSuperWhisper
+
+@MainActor
+final class MainWindowResizabilityTests: XCTestCase {
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 450, height: 650),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: true
+        )
+    }
+
+    // The bug: maxSize.width was pinned to the same 450 as minSize.width, so
+    // AppKit refused horizontal resizing no matter what SwiftUI declared.
+    func testSizeLimits_allowHorizontalResizing() {
+        let window = makeWindow()
+        AppDelegate.applyMainWindowSizeLimits(to: window)
+
+        XCTAssertGreaterThan(window.maxSize.width, window.minSize.width,
+                             "Main window must be widenable: max width has to exceed min width")
+    }
+
+    func testSizeLimits_preserveMinimumWidth() {
+        let window = makeWindow()
+        AppDelegate.applyMainWindowSizeLimits(to: window)
+
+        XCTAssertEqual(window.minSize.width, 450,
+                       "Minimum width is existing behavior and must not change")
+    }
+
+    // The decisive bug: windowWillResize rewrote every proposed width to 450,
+    // which overrides minSize/maxSize because AppKit consults the delegate on
+    // each resize. Height passed through untouched, which is why the window
+    // resized vertically but never horizontally.
+    func testWindowWillResize_honorsProposedWidth() {
+        let delegate = AppDelegate()
+        let result = delegate.windowWillResize(makeWindow(), to: NSSize(width: 900, height: 650))
+
+        XCTAssertEqual(result.width, 900,
+                       "windowWillResize must not override the user's horizontal drag")
+    }
+
+    func testWindowWillResize_leavesHeightUntouched() {
+        let delegate = AppDelegate()
+        let result = delegate.windowWillResize(makeWindow(), to: NSSize(width: 900, height: 720))
+
+        XCTAssertEqual(result.height, 720, "height handling is unchanged by this fix")
+    }
+
+    func testSizeLimits_preserveHeightRange() {
+        let window = makeWindow()
+        AppDelegate.applyMainWindowSizeLimits(to: window)
+
+        XCTAssertEqual(window.minSize.height, 400)
+        XCTAssertEqual(window.maxSize.height, 900,
+                       "The height cap is existing intentional behavior; this change is width-only")
+    }
+}


### PR DESCRIPTION
## Why

The main window is locked to 450pt wide and can't be widened, while it resizes vertically without complaint. Transcriptions are often long, so the narrow column makes the history list harder to read than it needs to be.

## Root cause

Three independent constraints pinned the width. All three had to go — fixing any one or two alone changes nothing, which is what made this less obvious than it looks:

1. **SwiftUI** — `.frame(width: 450)` on the root view set a *fixed* width, making the content's minimum and maximum identical. `.windowResizability(.contentMinSize)` then had nothing to resize.
2. **AppKit properties** — `adoptMainWindow` set `window.maxSize` width to 450, equal to `minSize.width`.
3. **AppKit delegate** — `windowWillResize(_:to:)` returned `NSSize(width: 450, height: frameSize.height)`, rewriting the width on *every* resize attempt.

The third was decisive: AppKit consults the delegate on each resize, and its return value overrides the window's own `minSize`/`maxSize`. It also explains the exact symptom — height was passed through untouched while width was hardcoded, so the window resized vertically but never horizontally.

## What changed

| | Before | After |
|---|---|---|
| SwiftUI frame | `.frame(width: 450)` | `.frame(minWidth: 450)` |
| `window.maxSize.width` | `450` | unbounded |
| `windowWillResize` | forced width to 450 | returns the proposed size |
| `.defaultSize` | 450 × 650 | **unchanged** |
| Height range | 400–900 | **unchanged** |

`ContentView` already declared `.frame(minWidth: 400, idealWidth: 400)`, so the content was always built to flex — only the outer constraints prevented it.

**Existing users see no difference on update.** The window still opens at 450 × 650; it simply *can* now be widened. SwiftUI persists the frame automatically, so a user who never drags it keeps exactly today's behavior.

## Tests

5 new unit tests in `MainWindowResizabilityTests`. The size limits are extracted into `AppDelegate.applyMainWindowSizeLimits(to:)` so they can be applied to a real `NSWindow` and asserted, following the pattern already used by `isMainAppWindow`:

- `testWindowWillResize_honorsProposedWidth` — fails against the old code, passes against the new. This is the real regression guard.
- `testWindowWillResize_leavesHeightUntouched`
- `testSizeLimits_allowHorizontalResizing` — max width must exceed min width
- `testSizeLimits_preserveMinimumWidth` — 450 floor retained
- `testSizeLimits_preserveHeightRange` — 400–900 retained

## Test plan

- [x] Window opens at 450 × 650 as before
- [x] Right and left edges now drag wider
- [x] Cannot be dragged narrower than 450pt
- [x] Vertical resizing still honors the 400–900 range
- [x] Size persists across relaunch (SwiftUI frame autosave)
