### PR TITLE
feat: list recent transcriptions in the status bar menu

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -215,33 +215,13 @@ class IndicatorViewModel: ObservableObject {
     }
     
     func insertText(_ text: String) {
-        guard !text.isEmpty else { return }
-        let finalText = Self.applyPostProcessing(text)
-        let prefs = AppPreferences.shared
-
-        if prefs.autoPasteTranscription {
-            if prefs.autoCopyToClipboard {
-                // Paste and keep in clipboard
-                ClipboardUtil.insertTextAndKeepInClipboard(finalText)
-            } else {
-                // Paste but restore original clipboard (legacy behavior)
-                ClipboardUtil.insertText(finalText)
-            }
-        } else if prefs.autoCopyToClipboard {
-            // Only copy to clipboard, don't paste
-            ClipboardUtil.copyToClipboard(finalText)
-        }
-        // If both are false, do nothing
-
+        TranscriptionInserter.insert(text)
     }
-    
+
+    /// Retained as the canonical symbol for existing tests; the implementation
+    /// now lives in `TranscriptionInserter`.
     static func applyPostProcessing(_ text: String) -> String {
-        guard AppPreferences.shared.addSpaceAfterSentence,
-              let lastChar = text.last,
-              lastChar.isPunctuation else {
-            return text
-        }
-        return text + " "
+        TranscriptionInserter.applyPostProcessing(text)
     }
     
     private func startBlinking() {

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -187,29 +187,47 @@ class RecordingStore: ObservableObject {
     /// `nonisolated` so plain `XCTestCase` classes can call it, matching
     /// `retentionCutoffDate` and `isDeletableRecordingURL` below.
     nonisolated static func lastPasteable(from recordings: [Recording]) -> Recording? {
-        recordings
+        recentPasteable(from: recordings, limit: 1).first
+    }
+
+    /// The most recent pasteable transcriptions, newest first, for the status
+    /// bar menu. Single source of truth for what "pasteable" means — the
+    /// single-item rule above delegates here rather than repeating the filters.
+    nonisolated static func recentPasteable(from recordings: [Recording], limit: Int) -> [Recording] {
+        guard limit > 0 else { return [] }
+
+        return recordings
             .filter { $0.status == .completed }
             .filter { !$0.transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            .max { $0.timestamp < $1.timestamp }
+            .sorted { $0.timestamp > $1.timestamp }
+            .prefix(limit)
+            .map { $0 }
     }
 
     /// The newest completed, non-empty transcription, or nil when there is none.
     func getLastPasteableRecording() -> Recording? {
+        getRecentPasteableRecordings(limit: 1).first
+    }
+
+    /// The most recent pasteable transcriptions, newest first.
+    func getRecentPasteableRecordings(limit: Int) -> [Recording] {
+        guard limit > 0 else { return [] }
+
         do {
             let candidates = try dbQueue.read { db in
-                // Narrow in SQL, then apply the full rule in Swift. The limit is
-                // a safety bound so a run of blank-but-completed rows cannot
-                // force a full-table read.
+                // Narrow in SQL, then apply the full rule in Swift. Over-fetching
+                // gives blank-but-completed rows room to be filtered out without
+                // risking a full-table read.
                 try Recording
                     .filter(Recording.Columns.status == RecordingStatus.completed.rawValue)
                     .order(Recording.Columns.timestamp.desc)
-                    .limit(20)
+                    .limit(max(limit * 4, 20))
                     .fetchAll(db)
             }
-            return Self.lastPasteable(from: candidates)
+            return Self.recentPasteable(from: candidates, limit: limit)
         } catch {
-            print("Failed to fetch last pasteable recording: \(error)")
-            return nil
+            print("Failed to fetch recent pasteable recordings: \(error)")
+            return []
         }
     }
 

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -177,6 +177,42 @@ class RecordingStore: ObservableObject {
         }
     }
 
+    /// Which transcription the paste-last-transcription hotkey should use:
+    /// the newest completed recording that actually has text.
+    ///
+    /// Pure and separately testable; `getLastPasteableRecording()` applies it
+    /// to rows read from the database. Keeping the rule here rather than in
+    /// SQL means there is exactly one definition of "pasteable".
+    ///
+    /// `nonisolated` so plain `XCTestCase` classes can call it, matching
+    /// `retentionCutoffDate` and `isDeletableRecordingURL` below.
+    nonisolated static func lastPasteable(from recordings: [Recording]) -> Recording? {
+        recordings
+            .filter { $0.status == .completed }
+            .filter { !$0.transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .max { $0.timestamp < $1.timestamp }
+    }
+
+    /// The newest completed, non-empty transcription, or nil when there is none.
+    func getLastPasteableRecording() -> Recording? {
+        do {
+            let candidates = try dbQueue.read { db in
+                // Narrow in SQL, then apply the full rule in Swift. The limit is
+                // a safety bound so a run of blank-but-completed rows cannot
+                // force a full-table read.
+                try Recording
+                    .filter(Recording.Columns.status == RecordingStatus.completed.rawValue)
+                    .order(Recording.Columns.timestamp.desc)
+                    .limit(20)
+                    .fetchAll(db)
+            }
+            return Self.lastPasteable(from: candidates)
+        } catch {
+            print("Failed to fetch last pasteable recording: \(error)")
+            return nil
+        }
+    }
+
     static let recordingsDidUpdateNotification = Notification.Name("RecordingStore.recordingsDidUpdate")
 
     func addRecording(_ recording: Recording) {

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -86,6 +86,13 @@ class AppState: ObservableObject {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+    /// How many recent transcriptions the status bar menu lists.
+    static let recentTranscriptionMenuCount = 5
+
+    /// Delay before pasting a transcription chosen from the status bar menu, to
+    /// let the menu dismiss and focus return to the user's previous app.
+    static let menuPasteFocusDelay: TimeInterval = 0.2
+
     private var statusItem: NSStatusItem?
     private var mainWindow: NSWindow?
     private var languageSubmenu: NSMenu?
@@ -93,6 +100,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private var microphoneObserver: AnyCancellable?
     private var recordingRetentionTimer: Timer?
     private var hideMainWindowAtLaunch = false
+    /// Cached transcription text for the menu's "Recent" section, newest first.
+    private var recentTranscriptions: [String] = []
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard !OpenSuperWhisperApp.isRunningTests else { return }
@@ -131,6 +140,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         OpenSuperWhisperApp.startTranscriptionQueue()
         observeMicrophoneChanges()
+
+        // Keeps the menu's "Recent" section current. Rebuilding on this
+        // notification rather than while the menu is opening avoids mutating a
+        // menu that AppKit is already displaying.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(recordingsDidUpdate),
+            name: RecordingStore.recordingsDidUpdateNotification,
+            object: nil
+        )
         
         IndicatorWindowManager.shared.warmUp()
         
@@ -138,6 +157,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         Task { @MainActor in
             await RecordingStore.shared.backfillMissingDurations()
+        }
+
+        // Populate the menu's "Recent" section from existing history, so it is
+        // present at launch rather than only after the next recording.
+        Task { @MainActor in
+            refreshRecentTranscriptions()
         }
     }
 
@@ -307,13 +332,74 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         
         microphoneMenu.submenu = submenu
         menu.addItem(microphoneMenu)
-        
+
+        addRecentTranscriptionsSection(to: menu)
+
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q"))
-        
+
         statusItem?.menu = menu
     }
+
+    /// Adds the "Recent" section listing the last few transcriptions, each of
+    /// which pastes at the cursor when chosen. Omitted entirely when there is
+    /// no history, so the menu does not carry an empty header.
+    private func addRecentTranscriptionsSection(to menu: NSMenu) {
+        let recent = recentTranscriptions
+        guard !recent.isEmpty else { return }
+
+        menu.addItem(NSMenuItem.separator())
+
+        let header = NSMenuItem(title: "Recent", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+
+        for transcription in recent {
+            let item = NSMenuItem(
+                title: TranscriptionMenuFormatter.menuTitle(for: transcription),
+                action: #selector(pasteRecentTranscription(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            // Carry the full text, not the truncated title, so the paste is complete.
+            item.representedObject = transcription
+            // The untruncated transcription on hover, for anything ambiguous.
+            item.toolTip = transcription
+            menu.addItem(item)
+        }
+    }
+
+    /// Refreshes the cached transcriptions, then rebuilds the menu.
+    ///
+    /// The fetch has to happen here rather than inside menu construction:
+    /// `RecordingStore` is `@MainActor`, while `updateStatusBarMenu` can be
+    /// reached from a `MicrophoneService` publisher that is not main-isolated.
+    /// Caching plain strings keeps menu building synchronous and isolation-free.
+    @MainActor
+    private func refreshRecentTranscriptions() {
+        recentTranscriptions = RecordingStore.shared
+            .getRecentPasteableRecordings(limit: Self.recentTranscriptionMenuCount)
+            .map(\.transcription)
+        updateStatusBarMenu()
+    }
+
+    @objc private func pasteRecentTranscription(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+
+        // Opening a status bar menu makes this app active. Pasting immediately
+        // would target OpenSuperWhisper rather than whatever the user was in, so
+        // give the menu time to dismiss and focus time to return first.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.menuPasteFocusDelay) {
+            TranscriptionInserter.insert(text, forcePaste: true)
+        }
+    }
     
+    @objc private func recordingsDidUpdate() {
+        Task { @MainActor in
+            refreshRecentTranscriptions()
+        }
+    }
+
     @objc private func selectMicrophone(_ sender: NSMenuItem) {
         guard let device = sender.representedObject as? MicrophoneService.AudioDevice else { return }
         microphoneService.selectMicrophone(device)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1344,7 +1344,36 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color(.controlBackgroundColor).opacity(0.3))
                 .cornerRadius(12)
-                
+
+                // Paste Last Transcription
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Paste Last Transcription")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Shortcut")
+                                .font(.subheadline)
+                            Spacer()
+                            KeyboardShortcuts.Recorder("", name: .pasteLastTranscription)
+                                .frame(width: 150)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color(.textBackgroundColor).opacity(0.5))
+                        .cornerRadius(8)
+
+                        Text("Pastes your most recent transcription at the cursor. Useful when the cursor wasn't where you wanted it when the recording finished.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.controlBackgroundColor).opacity(0.3))
+                .cornerRadius(12)
+
                 // Recording Behavior
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Recording Behavior")

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -9,6 +9,8 @@ import SwiftUI
 extension KeyboardShortcuts.Name {
     static let toggleRecord = Self("toggleRecord", default: .init(.backtick, modifiers: .option))
     static let escape = Self("escape", default: .init(.escape))
+    static let pasteLastTranscription = Self("pasteLastTranscription",
+                                             default: .init(.v, modifiers: [.command, .control]))
 }
 
 class ShortcutManager {
@@ -70,8 +72,29 @@ class ShortcutManager {
             }
         }
         KeyboardShortcuts.disable(.escape)
+
+        // Key-up rather than key-down, matching .escape above, so the
+        // synthesized Cmd+V cannot race the user's own modifier keys still
+        // being physically held down.
+        KeyboardShortcuts.onKeyUp(for: .pasteLastTranscription) {
+            Task { @MainActor in
+                Self.pasteLastTranscription()
+            }
+        }
     }
     
+    /// Pastes the most recent transcription at the current cursor position.
+    /// Always pastes, even when automatic pasting is disabled — an explicit
+    /// keypress is an explicit request.
+    @MainActor
+    static func pasteLastTranscription() {
+        guard let recording = RecordingStore.shared.getLastPasteableRecording() else {
+            print("Paste last transcription: no transcription available")
+            return
+        }
+        TranscriptionInserter.insert(recording.transcription, forcePaste: true)
+    }
+
     private func setupRecordingTrigger() {
         let modifierKey = ModifierKey(rawValue: AppPreferences.shared.modifierOnlyHotkey) ?? .none
         let mouseButton = MouseButton(rawValue: AppPreferences.shared.mouseButtonHotkey) ?? .none

--- a/OpenSuperWhisper/Utils/TranscriptionInserter.swift
+++ b/OpenSuperWhisper/Utils/TranscriptionInserter.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// How a transcription should reach the user's cursor and clipboard.
+enum InsertionAction: Equatable {
+    /// Paste, and leave the transcription on the clipboard.
+    case pasteKeepingClipboard
+    /// Paste, and restore the user's previous clipboard afterwards.
+    case pasteRestoringClipboard
+    /// Copy to the clipboard without pasting.
+    case copyOnly
+    /// Do nothing. Named `doNothing` rather than `none` so it can never be
+    /// confused with `Optional.none` at a call site.
+    case doNothing
+}
+
+/// The single entry point for putting a transcription in front of the user.
+/// Both the record-time path and the paste-last-transcription hotkey route
+/// through here so their behavior can never drift apart.
+@MainActor
+enum TranscriptionInserter {
+
+    /// Pure routing rule.
+    ///
+    /// `forcePaste` is used by the explicit paste-last-transcription hotkey:
+    /// an on-demand request to paste should paste even when the user has
+    /// turned automatic pasting off, because pasting is the entire point of
+    /// pressing it.
+    ///
+    /// `nonisolated` so plain `XCTestCase` classes can exercise it directly,
+    /// matching `RecordingStore.retentionCutoffDate`.
+    nonisolated static func action(autoPaste: Bool, autoCopy: Bool, forcePaste: Bool) -> InsertionAction {
+        if autoPaste || forcePaste {
+            return autoCopy ? .pasteKeepingClipboard : .pasteRestoringClipboard
+        }
+        return autoCopy ? .copyOnly : .doNothing
+    }
+
+    /// Appends a trailing space after terminal punctuation when the user has
+    /// that preference enabled.
+    static func applyPostProcessing(_ text: String) -> String {
+        guard AppPreferences.shared.addSpaceAfterSentence,
+              let lastChar = text.last,
+              lastChar.isPunctuation else {
+            return text
+        }
+        return text + " "
+    }
+
+    static func insert(_ text: String, forcePaste: Bool = false) {
+        guard !text.isEmpty else { return }
+
+        let finalText = applyPostProcessing(text)
+        let prefs = AppPreferences.shared
+
+        switch action(autoPaste: prefs.autoPasteTranscription,
+                      autoCopy: prefs.autoCopyToClipboard,
+                      forcePaste: forcePaste) {
+        case .pasteKeepingClipboard:
+            ClipboardUtil.insertTextAndKeepInClipboard(finalText)
+        case .pasteRestoringClipboard:
+            ClipboardUtil.insertText(finalText)
+        case .copyOnly:
+            ClipboardUtil.copyToClipboard(finalText)
+        case .doNothing:
+            break
+        }
+    }
+}

--- a/OpenSuperWhisper/Utils/TranscriptionMenuFormatter.swift
+++ b/OpenSuperWhisper/Utils/TranscriptionMenuFormatter.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Collapses transcriptions into short single-line labels for menu items.
+enum TranscriptionMenuFormatter {
+
+    /// Longest label body shown in the status bar menu, before the ellipsis.
+    static let maxTitleLength = 50
+
+    /// Renders a transcription as a single short line suitable for an
+    /// `NSMenuItem` title.
+    ///
+    /// Menu items render embedded newlines poorly and dictated text is often
+    /// several sentences, so every run of whitespace collapses to one space and
+    /// anything over `maxLength` is cut back to a word boundary and suffixed
+    /// with an ellipsis.
+    static func menuTitle(for transcription: String, maxLength: Int = maxTitleLength) -> String {
+        guard maxLength > 0 else { return "" }
+
+        let collapsed = transcription
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        guard collapsed.count > maxLength else { return collapsed }
+
+        let cutoff = collapsed.index(collapsed.startIndex, offsetBy: maxLength)
+        let head = collapsed[..<cutoff]
+
+        // Prefer cutting at the last space so a word is not sliced in half.
+        // A single word longer than the limit has no space to fall back to and
+        // is hard-cut instead.
+        if let lastSpace = head.lastIndex(of: " ") {
+            return collapsed[..<lastSpace] + "…"
+        }
+        return head + "…"
+    }
+}

--- a/OpenSuperWhisperTests/LastPasteableRecordingTests.swift
+++ b/OpenSuperWhisperTests/LastPasteableRecordingTests.swift
@@ -61,6 +61,58 @@ final class LastPasteableRecordingTests: XCTestCase {
         XCTAssertNil(RecordingStore.lastPasteable(from: recordings))
     }
 
+    // MARK: - recentPasteable (menu bar list)
+
+    func testRecentPasteable_returnsNewestFirst() {
+        let recordings = [
+            makeRecording("middle", secondsAgo: 50),
+            makeRecording("newest", secondsAgo: 10),
+            makeRecording("oldest", secondsAgo: 500),
+        ]
+        let result = RecordingStore.recentPasteable(from: recordings, limit: 5)
+
+        XCTAssertEqual(result.map(\.transcription), ["newest", "middle", "oldest"])
+    }
+
+    func testRecentPasteable_respectsLimit() {
+        let recordings = (1...10).map { makeRecording("item \($0)", secondsAgo: TimeInterval($0)) }
+        let result = RecordingStore.recentPasteable(from: recordings, limit: 5)
+
+        XCTAssertEqual(result.count, 5)
+        XCTAssertEqual(result.first?.transcription, "item 1", "smallest secondsAgo is newest")
+    }
+
+    func testRecentPasteable_fewerAvailableThanLimit_returnsAll() {
+        let recordings = [makeRecording("only one", secondsAgo: 10)]
+        XCTAssertEqual(RecordingStore.recentPasteable(from: recordings, limit: 5).count, 1)
+    }
+
+    func testRecentPasteable_appliesSameFiltersAsLastPasteable() {
+        let recordings = [
+            makeRecording("good", secondsAgo: 100),
+            makeRecording("", secondsAgo: 20),
+            makeRecording("  \n ", secondsAgo: 15),
+            makeRecording("still working", status: .transcribing, secondsAgo: 10),
+        ]
+        XCTAssertEqual(RecordingStore.recentPasteable(from: recordings, limit: 5).map(\.transcription),
+                       ["good"])
+    }
+
+    func testRecentPasteable_zeroLimit_returnsEmpty() {
+        let recordings = [makeRecording("something", secondsAgo: 10)]
+        XCTAssertTrue(RecordingStore.recentPasteable(from: recordings, limit: 0).isEmpty)
+    }
+
+    // lastPasteable must stay consistent with the list rule, not drift from it.
+    func testLastPasteable_matchesFirstOfRecentPasteable() {
+        let recordings = [
+            makeRecording("older", secondsAgo: 100),
+            makeRecording("newest", secondsAgo: 10),
+        ]
+        XCTAssertEqual(RecordingStore.lastPasteable(from: recordings)?.transcription,
+                       RecordingStore.recentPasteable(from: recordings, limit: 1).first?.transcription)
+    }
+
     // The rule must not depend on the caller having pre-sorted the array.
     func testLastPasteable_doesNotRelyOnInputOrdering() throws {
         let ascending = [

--- a/OpenSuperWhisperTests/LastPasteableRecordingTests.swift
+++ b/OpenSuperWhisperTests/LastPasteableRecordingTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+final class LastPasteableRecordingTests: XCTestCase {
+
+    private func makeRecording(_ transcription: String,
+                               status: RecordingStatus = .completed,
+                               secondsAgo: TimeInterval) -> Recording {
+        Recording(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000 - secondsAgo),
+            fileName: "\(UUID().uuidString).wav",
+            transcription: transcription,
+            duration: 1.0,
+            status: status,
+            progress: 1.0,
+            sourceFileURL: nil
+        )
+    }
+
+    func testLastPasteable_emptyInput_returnsNil() {
+        XCTAssertNil(RecordingStore.lastPasteable(from: []))
+    }
+
+    func testLastPasteable_picksMostRecent() throws {
+        let recordings = [
+            makeRecording("older", secondsAgo: 100),
+            makeRecording("newest", secondsAgo: 10),
+            makeRecording("oldest", secondsAgo: 500),
+        ]
+        let result = try XCTUnwrap(RecordingStore.lastPasteable(from: recordings))
+        XCTAssertEqual(result.transcription, "newest")
+    }
+
+    func testLastPasteable_ignoresIncompleteStatuses() throws {
+        let recordings = [
+            makeRecording("done", secondsAgo: 100),
+            makeRecording("in flight", status: .transcribing, secondsAgo: 10),
+            makeRecording("queued", status: .pending, secondsAgo: 5),
+            makeRecording("broken", status: .failed, secondsAgo: 1),
+        ]
+        let result = try XCTUnwrap(RecordingStore.lastPasteable(from: recordings))
+        XCTAssertEqual(result.transcription, "done")
+    }
+
+    func testLastPasteable_ignoresEmptyAndWhitespaceOnly() throws {
+        let recordings = [
+            makeRecording("real text", secondsAgo: 100),
+            makeRecording("", secondsAgo: 20),
+            makeRecording("   \n\t ", secondsAgo: 10),
+        ]
+        let result = try XCTUnwrap(RecordingStore.lastPasteable(from: recordings))
+        XCTAssertEqual(result.transcription, "real text")
+    }
+
+    func testLastPasteable_noUsableCandidates_returnsNil() {
+        let recordings = [
+            makeRecording("", secondsAgo: 20),
+            makeRecording("pending text", status: .pending, secondsAgo: 10),
+        ]
+        XCTAssertNil(RecordingStore.lastPasteable(from: recordings))
+    }
+
+    // The rule must not depend on the caller having pre-sorted the array.
+    func testLastPasteable_doesNotRelyOnInputOrdering() throws {
+        let ascending = [
+            makeRecording("oldest", secondsAgo: 500),
+            makeRecording("newest", secondsAgo: 10),
+        ]
+        let descending: [Recording] = ascending.reversed()
+
+        XCTAssertEqual(try XCTUnwrap(RecordingStore.lastPasteable(from: ascending)).transcription, "newest")
+        XCTAssertEqual(try XCTUnwrap(RecordingStore.lastPasteable(from: descending)).transcription, "newest")
+    }
+}

--- a/OpenSuperWhisperTests/TranscriptionInserterTests.swift
+++ b/OpenSuperWhisperTests/TranscriptionInserterTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+final class TranscriptionInserterActionTests: XCTestCase {
+
+    func testAction_autoPasteAndAutoCopy_pastesKeepingClipboard() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: true, autoCopy: true, forcePaste: false),
+            .pasteKeepingClipboard)
+    }
+
+    func testAction_autoPasteOnly_pastesRestoringClipboard() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: true, autoCopy: false, forcePaste: false),
+            .pasteRestoringClipboard)
+    }
+
+    func testAction_autoCopyOnly_copiesWithoutPasting() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: true, forcePaste: false),
+            .copyOnly)
+    }
+
+    func testAction_neitherEnabled_doesNothing() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: false, forcePaste: false),
+            .doNothing)
+    }
+
+    // forcePaste is the hotkey's contract: an explicit request always pastes,
+    // even for a user who has turned automatic pasting off.
+    func testAction_forcePaste_overridesDisabledAutoPaste() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: false, forcePaste: true),
+            .pasteRestoringClipboard)
+    }
+
+    func testAction_forcePaste_respectsKeepInClipboard() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: false, autoCopy: true, forcePaste: true),
+            .pasteKeepingClipboard)
+    }
+
+    func testAction_forcePaste_withAutoPasteAlreadyOn_isUnchanged() {
+        XCTAssertEqual(
+            TranscriptionInserter.action(autoPaste: true, autoCopy: false, forcePaste: true),
+            .pasteRestoringClipboard)
+    }
+}

--- a/OpenSuperWhisperTests/TranscriptionMenuFormatterTests.swift
+++ b/OpenSuperWhisperTests/TranscriptionMenuFormatterTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+final class TranscriptionMenuFormatterTests: XCTestCase {
+
+    func testMenuTitle_shortText_isUnchanged() {
+        XCTAssertEqual(
+            TranscriptionMenuFormatter.menuTitle(for: "Fix the deploy", maxLength: 50),
+            "Fix the deploy")
+    }
+
+    // NSMenuItem titles render newlines badly, so they must collapse away.
+    func testMenuTitle_collapsesNewlinesAndRunsOfWhitespace() {
+        XCTAssertEqual(
+            TranscriptionMenuFormatter.menuTitle(for: "one\ntwo\t\tthree   four", maxLength: 50),
+            "one two three four")
+    }
+
+    func testMenuTitle_trimsLeadingAndTrailingWhitespace() {
+        XCTAssertEqual(
+            TranscriptionMenuFormatter.menuTitle(for: "  \n padded \n ", maxLength: 50),
+            "padded")
+    }
+
+    func testMenuTitle_exactlyMaxLength_isNotTruncated() {
+        let text = String(repeating: "a", count: 20)
+        XCTAssertEqual(TranscriptionMenuFormatter.menuTitle(for: text, maxLength: 20), text)
+    }
+
+    func testMenuTitle_longText_isTruncatedWithEllipsis() {
+        let result = TranscriptionMenuFormatter.menuTitle(
+            for: "The quick brown fox jumps over the lazy dog and keeps running",
+            maxLength: 20)
+
+        XCTAssertTrue(result.hasSuffix("…"), "truncated titles must signal truncation")
+        XCTAssertLessThanOrEqual(result.count, 21, "body must fit maxLength, plus the ellipsis")
+    }
+
+    func testMenuTitle_truncatesOnWordBoundary() {
+        let result = TranscriptionMenuFormatter.menuTitle(
+            for: "The quick brown fox jumps",
+            maxLength: 14)
+
+        // "The quick brown" is 15 chars, so it must cut back to "The quick".
+        XCTAssertEqual(result, "The quick…")
+    }
+
+    func testMenuTitle_singleWordLongerThanLimit_isHardCut() {
+        let result = TranscriptionMenuFormatter.menuTitle(
+            for: "Pneumonoultramicroscopicsilicovolcanoconiosis",
+            maxLength: 10)
+
+        XCTAssertEqual(result, "Pneumonoul…")
+    }
+
+    func testMenuTitle_emptyText_returnsEmpty() {
+        XCTAssertEqual(TranscriptionMenuFormatter.menuTitle(for: "   \n ", maxLength: 50), "")
+    }
+
+    func testMenuTitle_nonPositiveMaxLength_returnsEmpty() {
+        XCTAssertEqual(TranscriptionMenuFormatter.menuTitle(for: "anything", maxLength: 0), "")
+    }
+}


### PR DESCRIPTION
> **Stacked on #190** — this branch builds on the paste-last-transcription hotkey, so the diff currently includes that PR's commits. Please review #190 first; once it merges, this diff reduces to just the menu changes. Happy to rebase or hold this until then.

## Why

The status bar menu is the fastest way to reach the app, but it can't do the thing you most often want from it: get a recent transcription into whatever you're typing in. Today that means opening the main window and copying out of the history list.

#190 adds a hotkey for the *most recent* transcription. This covers the case where the one you want isn't the last one.

## What

A `Recent` section between Microphone and Quit, listing the last 5 pasteable transcriptions. Choosing one pastes it at the cursor.

```
OpenSuperWhisper        ⌘O
Language                ▸
────────────────────────
Microphone              ▸
────────────────────────
Recent
  Okay so the thing I wanted to try…
  Let me check the deploy status on…
  Another feature I want is when I…
────────────────────────
Quit                    ⌘Q
```

- Titles collapse all whitespace and newlines to single spaces, then truncate at a word boundary to 50 characters with an ellipsis. Menu items render embedded newlines poorly, and dictated text is often several sentences.
- The full untruncated text is carried in `representedObject` and shown as a tooltip, so what you paste is complete and you can confirm on hover.
- The section is omitted entirely when there's no history, rather than showing an empty header.

## How

Pasting calls the same `TranscriptionInserter.insert(_:forcePaste:)` the hotkey uses, so the two can't diverge in clipboard behavior.

Selection generalizes the existing rule to `RecordingStore.recentPasteable(from:limit:)`, and `lastPasteable(from:)` now delegates to it. That keeps exactly one definition of "pasteable" rather than two filters that could drift, and there's a test asserting the two agree.

Two implementation notes:

**Paste timing.** Opening a status bar menu activates the app, so pasting immediately would target OpenSuperWhisper rather than the user's previous app. The paste is dispatched after `menuPasteFocusDelay` (0.2s) to let the menu dismiss and focus return. Verified working in practice; the value is a named constant if it needs tuning.

**Main-actor caching.** `RecordingStore` is `@MainActor`, but `updateStatusBarMenu` is reachable from the `MicrophoneService` publisher, which is not main-isolated (CoreAudio device callbacks). Fetching inside menu construction is therefore an isolation violation. The transcriptions are instead cached as plain strings on the main actor when `recordingsDidUpdateNotification` fires, keeping menu construction synchronous and isolation-free.

The menu is rebuilt on that notification rather than on menu-open, which avoids mutating a menu AppKit is already displaying.

## Tests

15 new unit tests, all passing:

- `TranscriptionMenuFormatterTests` — 9 tests: newline and whitespace collapsing, trimming, word-boundary truncation, hard-cut for a single over-long word, exact-length boundary, empty input, non-positive `maxLength`.
- `LastPasteableRecordingTests` — 6 added: newest-first ordering, limit respected, fewer-than-limit, same filters as the single-item rule, zero limit, and consistency between `lastPasteable` and `recentPasteable(limit: 1)`.

## Test plan

- [x] Menu shows up to 5 recent transcriptions, newest first
- [x] Long transcriptions truncate on a word boundary with an ellipsis
- [x] Multi-line transcriptions render as a single line
- [x] Choosing an item pastes the **full** text into the previously focused app
- [x] Tooltip shows the untruncated transcription
- [x] Section is absent with no history
- [x] List updates after a new recording without restarting the app

## Open questions

- **5 items** is a hardcoded constant (`recentTranscriptionMenuCount`). Happy to make it a preference if you'd prefer.
- **50 characters** likewise (`TranscriptionMenuFormatter.maxTitleLength`).
