### PR TITLE
Fix startup hang during microphone discovery

### DIFF
--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -193,7 +193,7 @@ class MicrophoneService: ObservableObject {
             return nil
         }
 
-        return value?.takeUnretainedValue() as String?
+        return value?.takeRetainedValue() as String?
     }
 
     private static func uint32Property(
@@ -289,26 +289,7 @@ class MicrophoneService: ObservableObject {
     
     private func getTransportType(for device: AudioDevice) -> UInt32 {
         guard let deviceID = getCoreAudioDeviceID(for: device) else { return 0 }
-        
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyTransportType,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        
-        var transportType: UInt32 = 0
-        var propertySize = UInt32(MemoryLayout<UInt32>.size)
-        
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(deviceID),
-            &propertyAddress,
-            0,
-            nil,
-            &propertySize,
-            &transportType
-        )
-        
-        return status == noErr ? transportType : 0
+        return Self.uint32Property(kAudioDevicePropertyTransportType, for: deviceID) ?? 0
     }
     
     func isActiveMicrophoneContinuity() -> Bool {

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -301,6 +301,12 @@ class MicrophoneService: ObservableObject {
     }
     
     func isContinuityMicrophone(_ device: AudioDevice) -> Bool {
+        let transportType = device.transportType ?? getTransportType(for: device)
+        if transportType == kAudioDeviceTransportTypeContinuityCaptureWired ||
+            transportType == kAudioDeviceTransportTypeContinuityCaptureWireless {
+            return true
+        }
+
         let name = device.name.lowercased()
         let id = device.id.lowercased()
         let manufacturer = (device.manufacturer ?? "").lowercased()

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -18,6 +18,21 @@ class MicrophoneService: ObservableObject {
         let name: String
         let manufacturer: String?
         let isBuiltIn: Bool
+        let transportType: UInt32?
+
+        init(
+            id: String,
+            name: String,
+            manufacturer: String?,
+            isBuiltIn: Bool,
+            transportType: UInt32? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.manufacturer = manufacturer
+            self.isBuiltIn = isBuiltIn
+            self.transportType = transportType
+        }
         
         static func == (lhs: AudioDevice, rhs: AudioDevice) -> Bool {
             return lhs.id == rhs.id
@@ -41,7 +56,7 @@ class MicrophoneService: ObservableObject {
         }
         timer?.invalidate()
     }
-    
+
     private func setupDeviceMonitoring() {
         deviceChangeObserver = NotificationCenter.default.addObserver(
             forName: .AVCaptureDeviceWasConnected,
@@ -63,77 +78,148 @@ class MicrophoneService: ObservableObject {
     }
     
     func refreshAvailableMicrophones() {
-        let deviceTypes: [AVCaptureDevice.DeviceType]
-        if #available(macOS 14.0, *) {
-            deviceTypes = [.microphone, .external]
-        } else {
-            deviceTypes = [.microphone, .external, .builtInMicrophone]
-        }
-        
-        let discoverySession = AVCaptureDevice.DiscoverySession(
-            deviceTypes: deviceTypes,
-            mediaType: .audio,
-            position: .unspecified
-        )
-        
-        availableMicrophones = discoverySession.devices
-            .filter { device in
-                !device.uniqueID.contains("CADefaultDeviceAggregate")
-            }
-            .map { device in
-                let isBuiltIn = isBuiltInDevice(device)
-                return AudioDevice(
-                    id: device.uniqueID,
-                    name: device.localizedName,
-                    manufacturer: device.manufacturer,
-                    isBuiltIn: isBuiltIn
-                )
-            }
+        availableMicrophones = Self.coreAudioInputDevices()
         
         if availableMicrophones.isEmpty {
             selectedMicrophone = nil
             currentMicrophone = nil
         }
     }
-    
-    private func isBuiltInDevice(_ device: AVCaptureDevice) -> Bool {
-        #if os(macOS)
-        if #available(macOS 14.0, *) {
-            if device.deviceType == .microphone {
-                let uniqueID = device.uniqueID.lowercased()
-                if uniqueID.contains("builtin") || uniqueID.contains("internal") {
-                    return true
-                }
-            }
-        } else {
-            if device.deviceType == .builtInMicrophone {
-                return true
-            }
+
+    private static func coreAudioInputDevices() -> [AudioDevice] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+
+        guard AudioObjectGetPropertyDataSize(
+            systemObject,
+            &address,
+            0,
+            nil,
+            &dataSize
+        ) == noErr else {
+            return []
         }
-        
-        let manufacturer = device.manufacturer
-        let mfr = manufacturer.lowercased()
-        if mfr.contains("apple") {
-            let uniqueID = device.uniqueID.lowercased()
-            let name = device.localizedName.lowercased()
-            
-            let isContinuity = name.contains("iphone") || name.contains("continuity") || name.contains("handoff") ||
-                               uniqueID.contains("iphone") || uniqueID.contains("continuity") || uniqueID.contains("handoff")
-            
-            if uniqueID.contains("builtin") || 
-               uniqueID.contains("internal") ||
-               (!uniqueID.contains("usb") &&
-               !uniqueID.contains("bluetooth") &&
-               !uniqueID.contains("airpods") &&
-               !isContinuity) {
-                return true
-            }
+
+        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        guard count > 0 else { return [] }
+
+        var deviceIDs = [AudioDeviceID](repeating: 0, count: count)
+        guard AudioObjectGetPropertyData(
+            systemObject,
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &deviceIDs
+        ) == noErr else {
+            return []
         }
-        
-        return false
-        #else
-        return device.deviceType == .builtInMicrophone
-        #endif
+
+        return deviceIDs.compactMap { deviceID in
+            guard hasInputStreams(deviceID),
+                  let uid = stringProperty(
+                    kAudioDevicePropertyDeviceUID,
+                    for: deviceID
+                  ),
+                  !uid.contains("CADefaultDeviceAggregate"),
+                  let name = stringProperty(
+                    kAudioObjectPropertyName,
+                    for: deviceID
+                  ) else {
+                return nil
+            }
+
+            let manufacturer = stringProperty(
+                kAudioObjectPropertyManufacturer,
+                for: deviceID
+            )
+            let transportType = uint32Property(
+                kAudioDevicePropertyTransportType,
+                for: deviceID
+            )
+
+            return AudioDevice(
+                id: uid,
+                name: name,
+                manufacturer: manufacturer,
+                isBuiltIn: transportType == kAudioDeviceTransportTypeBuiltIn,
+                transportType: transportType
+            )
+        }
+    }
+
+    private static func hasInputStreams(_ deviceID: AudioDeviceID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+
+        return AudioObjectGetPropertyDataSize(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &dataSize
+        ) == noErr && dataSize >= MemoryLayout<AudioStreamID>.size
+    }
+
+    private static func stringProperty(
+        _ selector: AudioObjectPropertySelector,
+        for deviceID: AudioDeviceID
+    ) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFString>?
+        var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+
+        guard AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &value
+        ) == noErr else {
+            return nil
+        }
+
+        return value?.takeUnretainedValue() as String?
+    }
+
+    private static func uint32Property(
+        _ selector: AudioObjectPropertySelector,
+        for deviceID: AudioDeviceID
+    ) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: UInt32 = 0
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+
+        guard AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &value
+        ) == noErr else {
+            return nil
+        }
+
+        return value
     }
     
     private func updateCurrentMicrophone() {
@@ -187,33 +273,21 @@ class MicrophoneService: ObservableObject {
     }
     
     func isBluetoothMicrophone(_ device: AudioDevice) -> Bool {
-        if let avDevice = AVCaptureDevice(uniqueID: device.id) {
-            let transportType = avDevice.transportType
-            if transportType == 1651275109 {
-                return true
-            }
-        }
-        
         let name = device.name.lowercased()
         let id = device.id.lowercased()
         let hasBluetoothInName = name.contains("bluetooth")
         let hasBluetoothInID = id.contains("bluetooth")
-        let macAddressPattern = "^[0-9A-Fa-f]{2}-[0-9A-Fa-f]{2}-[0-9A-Fa-f]{2}-[0-9A-Fa-f]{2}-[0-9A-Fa-f]{2}-[0-9A-Fa-f]{2}"
-        let hasMACAddress = id.range(of: macAddressPattern, options: .regularExpression) != nil
         
         if hasBluetoothInName || hasBluetoothInID {
             return true
         }
         
-        if hasMACAddress {
-            let transportType = getTransportType(for: device)
-            return transportType == 1651275109
-        }
-        
-        return false
+        let transportType = device.transportType ?? getTransportType(for: device)
+        return transportType == kAudioDeviceTransportTypeBluetooth ||
+               transportType == kAudioDeviceTransportTypeBluetoothLE
     }
     
-    private func getTransportType(for device: AudioDevice) -> Int32 {
+    private func getTransportType(for device: AudioDevice) -> UInt32 {
         guard let deviceID = getCoreAudioDeviceID(for: device) else { return 0 }
         
         var propertyAddress = AudioObjectPropertyAddress(
@@ -234,7 +308,7 @@ class MicrophoneService: ObservableObject {
             &transportType
         )
         
-        return status == noErr ? Int32(transportType) : 0
+        return status == noErr ? transportType : 0
     }
     
     func isActiveMicrophoneContinuity() -> Bool {
@@ -251,11 +325,6 @@ class MicrophoneService: ObservableObject {
         let hasIPhoneName = name.contains("iphone") || id.contains("iphone")
         let hasHandoffName = name.contains("handoff") || id.contains("handoff")
         return isApple && (hasContinuityName || hasIPhoneName || hasHandoffName)
-    }
-    
-    func getAVCaptureDevice() -> AVCaptureDevice? {
-        guard let active = getActiveMicrophone() else { return nil }
-        return AVCaptureDevice(uniqueID: active.id)
     }
     
     private func saveMicrophone(_ device: AudioDevice) {
@@ -282,31 +351,33 @@ class MicrophoneService: ObservableObject {
     func getCoreAudioDeviceID(for device: AudioDevice) -> AudioDeviceID? {
         var deviceID = device.id as CFString
         var audioDeviceID = AudioDeviceID()
-        var propertySize = UInt32(MemoryLayout<AudioDeviceID>.size)
-        
+
         var translationAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDeviceForUID,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
         
-        var translation = AudioValueTranslation(
-            mInputData: &deviceID,
-            mInputDataSize: UInt32(MemoryLayout<CFString>.size),
-            mOutputData: &audioDeviceID,
-            mOutputDataSize: UInt32(MemoryLayout<AudioDeviceID>.size)
-        )
-        
-        propertySize = UInt32(MemoryLayout<AudioValueTranslation>.size)
-        
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &translationAddress,
-            0,
-            nil,
-            &propertySize,
-            &translation
-        )
+        let status = withUnsafeMutablePointer(to: &deviceID) { deviceIDPointer in
+            withUnsafeMutablePointer(to: &audioDeviceID) { audioDeviceIDPointer in
+                var translation = AudioValueTranslation(
+                    mInputData: UnsafeMutableRawPointer(deviceIDPointer),
+                    mInputDataSize: UInt32(MemoryLayout<CFString>.size),
+                    mOutputData: UnsafeMutableRawPointer(audioDeviceIDPointer),
+                    mOutputDataSize: UInt32(MemoryLayout<AudioDeviceID>.size)
+                )
+                var propertySize = UInt32(MemoryLayout<AudioValueTranslation>.size)
+
+                return AudioObjectGetPropertyData(
+                    AudioObjectID(kAudioObjectSystemObject),
+                    &translationAddress,
+                    0,
+                    nil,
+                    &propertySize,
+                    &translation
+                )
+            }
+        }
         
         return status == noErr ? audioDeviceID : nil
     }
@@ -483,4 +554,3 @@ class MicrophoneService: ObservableObject {
 extension Notification.Name {
     static let microphoneDidChange = Notification.Name("microphoneDidChange")
 }
-

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -362,7 +362,8 @@ class MicrophoneService: ObservableObject {
             }
         }
         
-        return status == noErr ? audioDeviceID : nil
+        guard status == noErr, audioDeviceID != kAudioObjectUnknown else { return nil }
+        return audioDeviceID
     }
     
     func setAsSystemDefaultInput(_ device: AudioDevice) -> Bool {

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -78,7 +78,11 @@ class MicrophoneService: ObservableObject {
     }
     
     func refreshAvailableMicrophones() {
-        availableMicrophones = Self.coreAudioInputDevices()
+        guard let devices = Self.coreAudioInputDevices() else {
+            return
+        }
+
+        availableMicrophones = devices
         
         if availableMicrophones.isEmpty {
             selectedMicrophone = nil
@@ -86,7 +90,7 @@ class MicrophoneService: ObservableObject {
         }
     }
 
-    private static func coreAudioInputDevices() -> [AudioDevice] {
+    private static func coreAudioInputDevices() -> [AudioDevice]? {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDevices,
             mScope: kAudioObjectPropertyScopeGlobal,
@@ -102,7 +106,7 @@ class MicrophoneService: ObservableObject {
             nil,
             &dataSize
         ) == noErr else {
-            return []
+            return nil
         }
 
         let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
@@ -117,7 +121,7 @@ class MicrophoneService: ObservableObject {
             &dataSize,
             &deviceIDs
         ) == noErr else {
-            return []
+            return nil
         }
 
         let returnedCount = min(Int(dataSize) / MemoryLayout<AudioDeviceID>.size, count)
@@ -230,11 +234,8 @@ class MicrophoneService: ObservableObject {
             return
         }
         
-        if isDeviceAvailable(selected) {
-            currentMicrophone = selected
-        } else {
-            currentMicrophone = getDefaultMicrophone()
-        }
+        currentMicrophone = availableMicrophones.first(where: { $0.id == selected.id })
+            ?? getDefaultMicrophone()
     }
     
     func isDeviceAvailable(_ device: AudioDevice) -> Bool {

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -120,7 +120,9 @@ class MicrophoneService: ObservableObject {
             return []
         }
 
-        return deviceIDs.compactMap { deviceID in
+        let returnedCount = min(Int(dataSize) / MemoryLayout<AudioDeviceID>.size, count)
+
+        return deviceIDs.prefix(returnedCount).compactMap { deviceID in
             guard hasInputStreams(deviceID),
                   let uid = stringProperty(
                     kAudioDevicePropertyDeviceUID,

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -128,14 +128,14 @@ class MicrophoneService: ObservableObject {
                     kAudioDevicePropertyDeviceUID,
                     for: deviceID
                   ),
-                  !uid.contains("CADefaultDeviceAggregate"),
-                  let name = stringProperty(
-                    kAudioObjectPropertyName,
-                    for: deviceID
-                  ) else {
+                  !uid.contains("CADefaultDeviceAggregate") else {
                 return nil
             }
 
+            let name = stringProperty(
+                kAudioObjectPropertyName,
+                for: deviceID
+            ) ?? uid
             let manufacturer = stringProperty(
                 kAudioObjectPropertyManufacturer,
                 for: deviceID

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -602,6 +602,23 @@ final class MicrophoneServiceRequiresConnectionTests: XCTestCase {
         XCTAssertTrue(MicrophoneService.shared.isContinuityMicrophone(device))
         XCTAssertTrue(MicrophoneService.shared.isBluetoothMicrophone(device) || MicrophoneService.shared.isContinuityMicrophone(device))
     }
+
+    func testRequiresConnection_ContinuityTransportWithoutManufacturer() {
+        for transportType in [
+            kAudioDeviceTransportTypeContinuityCaptureWired,
+            kAudioDeviceTransportTypeContinuityCaptureWireless,
+        ] {
+            let device = MicrophoneService.AudioDevice(
+                id: "continuity-device-\(transportType)",
+                name: "External microphone",
+                manufacturer: nil,
+                isBuiltIn: false,
+                transportType: transportType
+            )
+
+            XCTAssertTrue(MicrophoneService.shared.isContinuityMicrophone(device))
+        }
+    }
     
     func testRequiresConnection_Bluetooth() {
         let device = MicrophoneService.AudioDevice(

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import Carbon
 import ApplicationServices
 import AVFoundation
+import CoreAudio
 @testable import OpenSuperWhisper
 
 final class OpenSuperWhisperTests: XCTestCase {
@@ -369,32 +370,6 @@ final class MicrophoneInventoryTests: XCTestCase {
             print("  isContinuity: \(service.isContinuityMicrophone(device))")
             print("  isBluetooth: \(service.isBluetoothMicrophone(device))")
         }
-        
-        let deviceTypes: [AVCaptureDevice.DeviceType]
-        if #available(macOS 14.0, *) {
-            deviceTypes = [.microphone, .external]
-        } else {
-            deviceTypes = [.microphone, .external, .builtInMicrophone]
-        }
-        
-        let discoverySession = AVCaptureDevice.DiscoverySession(
-            deviceTypes: deviceTypes,
-            mediaType: .audio,
-            position: .unspecified
-        )
-        
-        print("AVCaptureDevice count: \(discoverySession.devices.count)")
-        for device in discoverySession.devices {
-            print("AVCaptureDevice:")
-            print("  localizedName: \(device.localizedName)")
-            print("  uniqueID: \(device.uniqueID)")
-            print("  manufacturer: \(device.manufacturer)")
-            print("  deviceType: \(device.deviceType.rawValue)")
-            if #available(macOS 13.0, *) {
-                print("  isConnected: \(device.isConnected)")
-            }
-            print("  transportType: \(device.transportType)")
-        }
     }
 }
 
@@ -582,14 +557,26 @@ final class MicrophoneServiceBluetoothTests: XCTestCase {
         XCTAssertTrue(MicrophoneService.shared.isBluetoothMicrophone(device))
     }
     
-    func testBluetoothDetection_MACAddress() {
+    func testBluetoothDetection_BluetoothTransport() {
         let device = MicrophoneService.AudioDevice(
             id: "00-22-BB-71-21-0A:input",
             name: "Amiron wireless",
             manufacturer: "Apple",
-            isBuiltIn: false
+            isBuiltIn: false,
+            transportType: kAudioDeviceTransportTypeBluetooth
         )
         XCTAssertTrue(MicrophoneService.shared.isBluetoothMicrophone(device))
+    }
+
+    func testBluetoothDetection_MACAddressWithoutBluetoothTransport() {
+        let device = MicrophoneService.AudioDevice(
+            id: "00-22-BB-71-21-0A:input",
+            name: "External microphone",
+            manufacturer: "Example",
+            isBuiltIn: false,
+            transportType: kAudioDeviceTransportTypeUSB
+        )
+        XCTAssertFalse(MicrophoneService.shared.isBluetoothMicrophone(device))
     }
     
     func testBluetoothDetection_NotBluetooth() {
@@ -621,7 +608,8 @@ final class MicrophoneServiceRequiresConnectionTests: XCTestCase {
             id: "00-22-BB-71-21-0A:input",
             name: "Amiron wireless",
             manufacturer: "Apple",
-            isBuiltIn: false
+            isBuiltIn: false,
+            transportType: kAudioDeviceTransportTypeBluetooth
         )
         XCTAssertTrue(MicrophoneService.shared.isBluetoothMicrophone(device))
     }

--- a/OpenSuperWhisperUITests/OpenSuperWhisperUITests.swift
+++ b/OpenSuperWhisperUITests/OpenSuperWhisperUITests.swift
@@ -34,14 +34,14 @@ final class OpenSuperWhisperUITests: XCTestCase {
             )
         }
         app.launchArguments = [
-            "-hasCompletedOnboarding", "NO",
-            "-startHiddenInMenuBar", "NO",
+            "-hasCompletedOnboarding", "0",
+            "-startHiddenInMenuBar", "0",
         ]
         app.launch()
 
         XCTAssertTrue(
             app.windows.firstMatch.waitForExistence(timeout: 5),
-            "The main window must appear instead of blocking during application initialization"
+            "The application window must appear instead of blocking during application initialization"
         )
     }
 

--- a/OpenSuperWhisperUITests/OpenSuperWhisperUITests.swift
+++ b/OpenSuperWhisperUITests/OpenSuperWhisperUITests.swift
@@ -23,12 +23,26 @@ final class OpenSuperWhisperUITests: XCTestCase {
     }
 
     @MainActor
-    func testExample() throws {
+    func testLaunchShowsMainWindow() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
+        if app.state != .notRunning {
+            app.terminate()
+            XCTAssertTrue(
+                app.wait(for: .notRunning, timeout: 2),
+                "An existing application instance must terminate before the launch regression runs"
+            )
+        }
+        app.launchArguments = [
+            "-hasCompletedOnboarding", "NO",
+            "-startHiddenInMenuBar", "NO",
+        ]
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertTrue(
+            app.windows.firstMatch.waitForExistence(timeout: 5),
+            "The main window must appear instead of blocking during application initialization"
+        )
     }
 
     @MainActor

--- a/OpenSuperWhisperUITests/OpenSuperWhisperUITests.swift
+++ b/OpenSuperWhisperUITests/OpenSuperWhisperUITests.swift
@@ -26,6 +26,11 @@ final class OpenSuperWhisperUITests: XCTestCase {
     func testLaunchShowsMainWindow() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
+        defer {
+            app.terminate()
+            _ = app.wait(for: .notRunning, timeout: 2)
+        }
+
         if app.state != .notRunning {
             app.terminate()
             XCTAssertTrue(
@@ -34,7 +39,7 @@ final class OpenSuperWhisperUITests: XCTestCase {
             )
         }
         app.launchArguments = [
-            "-hasCompletedOnboarding", "0",
+            "-hasCompletedOnboarding", "1",
             "-startHiddenInMenuBar", "0",
         ]
         app.launch()


### PR DESCRIPTION
# Fix startup hang during microphone discovery

Fixes #193

## Problem

`MicrophoneService.shared` is initialized before SwiftUI creates the main
window. On the affected macOS 26.5.1 system,
`AVCaptureDevice.DiscoverySession` blocks in synchronous CoreMediaIO plug-in
initialization, leaving a live application process with no window.

`AVCaptureDevice(uniqueID:)`, used by Bluetooth detection, enters the same
blocked subsystem.

## Change

- Enumerate macOS audio input devices through CoreAudio.
- Preserve device UID, name, manufacturer, built-in classification, and
  aggregate-device filtering.
- Read Bluetooth transport using the named CoreAudio transport constants.
- Require CoreAudio Bluetooth transport metadata instead of classifying every
  MAC-shaped device UID as Bluetooth.
- Preserve Continuity microphone detection through CoreAudio's wired and
  wireless Continuity transport metadata.
- Remove the remaining synchronous `AVCaptureDevice(uniqueID:)` query.
- Scope `AudioValueTranslation` pointers for the duration of the CoreAudio call.
- Preserve the current inventory on transient CoreAudio errors and tolerate
  device-list churn or missing optional device names.
- Refresh persisted microphone metadata from the live inventory and reject
  unknown CoreAudio object IDs.
- Remove the AVFoundation discovery diagnostic that could hang the unit target.
- Add an end-to-end launch test requiring the first window within five seconds.

## Why CoreAudio

CoreAudio provides the audio-device inventory and transport metadata needed by
`MicrophoneService` without initializing the CoreMediaIO capture-device plug-in
path that blocks the affected system.

The underlying reason CoreMediaIO does not return on that installation remains
unknown. This PR removes the application's synchronous startup dependency on
that path.

## Verification

Environment:

- MacBook Pro, arm64
- macOS 26.5.1, build 25F80
- Xcode 26.5, build 17F42

Results:

- Clean build: `./run.sh build` succeeded.
- Unit target excluding the unrelated Accessibility-dependent TextEdit
  integration suite: 144 total, 129 passed, 0 failed, 15 environment/layout
  skips.
- Launch regression: 1 passed, 0 failed, window appeared in approximately
  3.9 seconds.
- Manual source launch: application visible with its window.
- Manual built-in-microphone recording and transcription succeeded.

## Scope

This PR intentionally excludes:

- local `GGML_NATIVE=OFF` build configuration;
- `libomp.dylib` replacement changes;
- keyboard-input-source filtering;
- Accessibility handling for TextEdit integration tests.

Those were separate findings during validation and should be reviewed
independently.

## Remaining coverage

USB, Bluetooth, and Continuity microphone hot-plug and recording were not
manually tested on the affected machine. CoreAudio device-list monitoring is
being handled separately in #178.
