### PR TITLE
feat: support file-based transcription prompt override

### DIFF
--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -619,6 +619,13 @@ func huggingFaceOwner(fromPageURL url: URL) -> String? {
 struct Settings {
     static let asianLanguages: Set<String> = ["zh", "ja", "ko"]
     
+    /// Path to the optional file-based transcription prompt.
+    /// When this file exists, its contents override the UI prompt setting.
+    static let promptFilePath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.config/opensuperwhisper/prompt.md"
+    }()
+    
     var selectedLanguage: String
     var suppressBlankAudio: Bool
     var showTimestamps: Bool
@@ -644,10 +651,23 @@ struct Settings {
         self.showTimestamps = prefs.showTimestamps
         self.temperature = prefs.temperature
         self.noSpeechThreshold = prefs.noSpeechThreshold
-        self.initialPrompt = prefs.initialPrompt
+        self.initialPrompt = Self.fileBasedPrompt() ?? prefs.initialPrompt
         self.useBeamSearch = prefs.useBeamSearch
         self.beamSize = prefs.beamSize
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
+    }
+    
+    /// Reads the transcription prompt from `~/.config/opensuperwhisper/prompt.md`.
+    /// Returns `nil` if the file does not exist or cannot be read.
+    private static func fileBasedPrompt() -> String? {
+        guard FileManager.default.isReadableFile(atPath: promptFilePath) else {
+            return nil
+        }
+        guard let contents = try? String(contentsOfFile: promptFilePath, encoding: .utf8) else {
+            return nil
+        }
+        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -625,7 +625,7 @@ struct Settings {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return "\(home)/.config/opensuperwhisper/prompt.md"
     }()
-    
+
     var selectedLanguage: String
     var suppressBlankAudio: Bool
     var showTimestamps: Bool
@@ -656,7 +656,7 @@ struct Settings {
         self.beamSize = prefs.beamSize
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
     }
-    
+
     /// Reads the transcription prompt from `~/.config/opensuperwhisper/prompt.md`.
     /// Returns `nil` if the file does not exist or cannot be read.
     private static func fileBasedPrompt() -> String? {

--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,26 @@ brew install opensuperwhisper
 
 Or from [GitHub releases page](https://github.com/Starmel/OpenSuperWhisper/releases).
 
+## Configuration
+
+### File-based transcription prompt
+
+Power users can set the Whisper transcription prompt via a file instead of the
+Settings UI. Create `~/.config/opensuperwhisper/prompt.md` with your desired
+prompt text:
+
+```shell
+mkdir -p ~/.config/opensuperwhisper
+echo "Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL." \
+  > ~/.config/opensuperwhisper/prompt.md
+```
+
+- The file is read fresh on every transcription — edits take effect immediately
+  without restarting the app.
+- When the file exists and is non-empty, it overrides the prompt entered in
+  Settings.
+- Delete or empty the file to revert to the Settings UI prompt.
+
 ## Requirements
 
 - macOS (Apple Silicon/ARM64)


### PR DESCRIPTION
## Intent

Add file-based transcription prompt support: on each transcription, check if ~/.config/opensuperwhisper/prompt.md exists and is readable. If so, use its trimmed contents as the Whisper initialPrompt parameter, overriding the Settings UI value. If absent or empty, fall back to existing Settings UI prompt (no behavior change). The file is read fresh each transcription so edits take effect immediately without restart. No new UI, no directory auto-creation — power-user feature. README documents the feature under a new Configuration section.

## What Changed

- Added `fileBasedPrompt()` in `Settings.swift` that reads `~/.config/opensuperwhisper/prompt.md` on each transcription and uses its trimmed contents as the Whisper `initialPrompt`, overriding the Settings UI value when the file exists and is non-empty.
- The `Settings` initializer now resolves the prompt as `Self.fileBasedPrompt() ?? prefs.initialPrompt`, falling back to the existing UI preference when the file is absent or empty.
- Added a "Configuration" section to `Readme.md` documenting the file-based prompt feature, including setup instructions and behavior notes.

## Risk Assessment

✅ Low: Small, well-bounded additive feature with proper fallback to existing behavior; no breaking changes, no security concerns, and all intent criteria are satisfied.

## Testing

Extracted the fileBasedPrompt logic into standalone Swift scripts and exercised all behavioral scenarios from the user intent: file absent (fallback), file with content (override), empty/whitespace file (fallback), fresh re-reads on edit (no restart), no directory auto-creation, and correct priority over Settings UI value. All 9 unit assertions and 3 additional verification scripts pass. Full xcodebuild linking is blocked by missing pre-built native libraries (whisper.cpp, autocorrect) that require cmake+cargo setup, but Swift type-checking of the new code compiles cleanly.

<details>
<summary>Evidence: End-to-end demo output showing all prompt scenarios</summary>

<code>╔══════════════════════════════════════════════════════════════════╗&#10;║ End-to-end demo: file-based transcription prompt ║&#10;╚══════════════════════════════════════════════════════════════════╝&#10;&#10;1. No prompt file exists yet:&#10;Effective prompt = &#34;Default UI prompt&#34;&#10;→ Falls back to Settings UI value ✓&#10;&#10;2. User creates prompt file (as shown in README):&#10;$ echo &#34;Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL.&#34; &gt; ~/.config/opensuperwhisper/prompt.md&#10;Effective prompt = &#34;Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL.&#34;&#10;→ File content used ✓&#10;&#10;3. User edits the file (no restart needed):&#10;$ echo &#34;Focus on code review terminology. Avoid filler words.&#34; &gt; ~/.config/opensuperwhisper/prompt.md&#10;Effective prompt = &#34;Focus on code review terminology. Avoid filler words.&#34;&#10;→ New content picked up immediately ✓&#10;&#10;4. User empties the file to revert:&#10;$ echo -n &gt; ~/.config/opensuperwhisper/prompt.md&#10;Effective prompt = &#34;Default UI prompt&#34;&#10;→ Falls back to Settings UI value ✓&#10;&#10;5. User deletes the file:&#10;$ rm ~/.config/opensuperwhisper/prompt.md&#10;Effective prompt = &#34;Default UI prompt&#34;&#10;→ Falls back to Settings UI value ✓&#10;&#10;═══════════════════════════════════════════════════════════════════&#10;All scenarios match user intent. Feature works correctly.&#10;═══════════════════════════════════════════════════════════════════</code>

```text
╔══════════════════════════════════════════════════════════════════╗
║  End-to-end demo: file-based transcription prompt               ║
╚══════════════════════════════════════════════════════════════════╝

1. No prompt file exists yet:
   Effective prompt = "Default UI prompt"
   → Falls back to Settings UI value ✓

2. User creates prompt file (as shown in README):
   $ echo "Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL." > ~/.config/opensuperwhisper/prompt.md
   Effective prompt = "Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL."
   → File content used ✓

3. User edits the file (no restart needed):
   $ echo "Focus on code review terminology. Avoid filler words." > ~/.config/opensuperwhisper/prompt.md
   Effective prompt = "Focus on code review terminology. Avoid filler words."
   → New content picked up immediately ✓

4. User empties the file to revert:
   $ echo -n > ~/.config/opensuperwhisper/prompt.md
   Effective prompt = "Default UI prompt"
   → Falls back to Settings UI value ✓

5. User deletes the file:
   $ rm ~/.config/opensuperwhisper/prompt.md
   Effective prompt = "Default UI prompt"
   → Falls back to Settings UI value ✓

═══════════════════════════════════════════════════════════════════
All scenarios match user intent. Feature works correctly.
═══════════════════════════════════════════════════════════════════
```
</details>
<details>
<summary>Evidence: Behavioral test script (9 assertions)</summary>

```text
#!/usr/bin/env swift
// Test: file-based prompt logic extracted from Settings.swift
// Validates the core behavior described in user intent.

import Foundation

// ─── Extracted logic (mirrors Settings.fileBasedPrompt) ───────────────────────
let promptFilePath: String = {
    let home = FileManager.default.homeDirectoryForCurrentUser.path
    return "\(home)/.config/opensuperwhisper/prompt.md"
}()

func fileBasedPrompt() -> String? {
    guard FileManager.default.isReadableFile(atPath: promptFilePath) else {
        return nil
    }
    guard let contents = try? String(contentsOfFile: promptFilePath, encoding: .utf8) else {
        return nil
    }
    let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
    return trimmed.isEmpty ? nil : trimmed
}

// ─── Test infrastructure ──────────────────────────────────────────────────────
var passed = 0
var failed = 0
func assert(_ condition: Bool, _ msg: String, file: String = #file, line: Int = #line) {
    if condition {
        passed += 1
        print("  PASS: \(msg)")
    } else {
        failed += 1
        print("  FAIL (\(file):\(line)): \(msg)")
    }
}

let fm = FileManager.default
let configDir = (promptFilePath as NSString).deletingLastPathComponent

// ─── Setup: ensure clean state ─────────────────────────────────────────────────
let backupPath = promptFilePath + ".bak-\(UUID().uuidString)"
let hadExistingFile = fm.fileExists(atPath: promptFilePath)
if hadExistingFile {
    try! fm.moveItem(atPath: promptFilePath, toPath: backupPath)
}

defer {
    // Restore original state
    try? fm.removeItem(atPath: promptFilePath)
    if hadExistingFile {
        try? fm.moveItem(atPath: backupPath, toPath: promptFilePath)
    } else {
        // Remove config dir only if we created it
        let dirContents = (try? fm.contentsOfDirectory(atPath: configDir)) ?? []
        if dirContents.isEmpty {
            try? fm.removeItem(atPath: configDir)
        }
    }
}

print("promptFilePath = \(promptFilePath)")
print("")

// ─── Test 1: File absent → returns nil (falls back to Settings UI) ───────────
print("Test 1: File absent → nil")
try? fm.removeItem(atPath: promptFilePath)
assert(fileBasedPrompt() == nil, "No file → nil")

// ─── Test 2: File present with content → returns trimmed content ──────────────
print("Test 2: File with content → trimmed content")
try! fm.createDirectory(atPath: configDir, withIntermediateDirectories: true)
try! "  Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL.  \n".write(toFile: promptFilePath, atomically: true, encoding: .utf8)
let result2 = fileBasedPrompt()
assert(result2 == "Use proper punctuation. Technical terms: Kubernetes, gRPC, PostgreSQL.", "Content trimmed correctly, got: \(result2 ?? "nil")")

// ─── Test 3: File present but empty → returns nil ─────────────────────────────
print("Test 3: Empty file → nil")
try! "".write(toFile: promptFilePath, atomically: true, encoding: .utf8)
assert(fileBasedPrompt() == nil, "Empty file → nil")

// ─── Test 4: File with only whitespace → returns nil ──────────────────────────
print("Test 4: Whitespace-only file → nil")
try! "   \n\n  \t  \n".write(toFile: promptFilePath, atomically: true, encoding: .utf8)
assert(fileBasedPrompt() == nil, "Whitespace-only → nil")

// ─── Test 5: File re-read freshness (edit takes effect immediately) ───────────
print("Test 5: Re-read freshness (edit between calls)")
try! "First prompt".write(toFile: promptFilePath, atomically: true, encoding: .utf8)
assert(fileBasedPrompt() == "First prompt", "First read: 'First prompt'")
try! "Second prompt".write(toFile: promptFilePath, atomically: true, encoding: .utf8)
assert(fileBasedPrompt() == "Second prompt", "Second read after edit: 'Second prompt'")

// ─── Test 6: Multiline file → trimmed but inner newlines preserved ────────────
print("Test 6: Multiline content preserved (only outer whitespace trimmed)")
let multi = "\n  Line one.\n  Line two.\n  "
try! multi.write(toFile: promptFilePath, atomically: true, encoding: .utf8)
let result6 = fileBasedPrompt()
assert(result6 == "Line one.\n  Line two.", "Multiline preserved: got \(result6 ?? "nil")")

// ─── Test 7: Priority over Settings UI value ──────────────────────────────────
print("Test 7: File prompt overrides prefs.initialPrompt (simulated)")
let prefsPrompt = "UI prompt"
try! "File prompt".write(toFile: promptFilePath, atomically: true, encoding: .utf8)
let effectivePrompt = fileBasedPrompt() ?? prefsPrompt
assert(effectivePrompt == "File prompt", "File takes priority over UI: got \(effectivePrompt)")

// ─── Test 8: Fallback when file absent ────────────────────────────────────────
print("Test 8: Fallback to UI prompt when file absent")
try! fm.removeItem(atPath: promptFilePath)
let effectivePrompt2 = fileBasedPrompt() ?? prefsPrompt
assert(effectivePrompt2 == "UI prompt", "Falls back to UI when no file: got \(effectivePrompt2)")

// ─── Summary ──────────────────────────────────────────────────────────────────
print("")
print("═══════════════════════════════════════════")
print("Results: \(passed) passed, \(failed) failed")
print("═══════════════════════════════════════════")
if failed > 0 { exit(1) }
```
</details>
<details>
<summary>Evidence: No-directory-autocreation verification</summary>

```text
#!/usr/bin/env swift
// Verify that the implementation does NOT auto-create the directory.
// Per user intent: "No new UI, no directory auto-creation"

import Foundation

let fm = FileManager.default
let home = fm.homeDirectoryForCurrentUser.path
let configDir = "\(home)/.config/opensuperwhisper"
let promptFile = "\(configDir)/prompt.md"

// Remove the directory entirely if it exists (save & restore)
let backupDir = "/tmp/osw-test-backup-\(UUID().uuidString)"
let dirExisted = fm.fileExists(atPath: configDir)
if dirExisted {
    try! fm.moveItem(atPath: configDir, toPath: backupDir)
}

defer {
    // Restore
    try? fm.removeItem(atPath: configDir)
    if dirExisted {
        try? fm.moveItem(atPath: backupDir, toPath: configDir)
    }
}

// Call the logic
func fileBasedPrompt() -> String? {
    guard fm.isReadableFile(atPath: promptFile) else { return nil }
    guard let contents = try? String(contentsOfFile: promptFile, encoding: .utf8) else { return nil }
    let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
    return trimmed.isEmpty ? nil : trimmed
}

let result = fileBasedPrompt()
let dirCreated = fm.fileExists(atPath: configDir)

print("Result when dir absent: \(result ?? "nil")")
print("Directory auto-created: \(dirCreated)")

if result == nil && !dirCreated {
    print("PASS: No directory auto-creation, nil returned gracefully")
    exit(0)
} else {
    print("FAIL: Unexpected behavior")
    exit(1)
}
```
</details>
<details>
<summary>Evidence: Type-check verification of Settings.swift pattern</summary>

```text
// Minimal type-check of the new code added in Settings.swift
// Validates that the added code compiles correctly with Foundation APIs.

import Foundation

struct SettingsTypeCheck {
    static let promptFilePath: String = {
        let home = FileManager.default.homeDirectoryForCurrentUser.path
        return "\(home)/.config/opensuperwhisper/prompt.md"
    }()
    
    var initialPrompt: String
    
    init(prefsInitialPrompt: String) {
        self.initialPrompt = Self.fileBasedPrompt() ?? prefsInitialPrompt
    }
    
    private static func fileBasedPrompt() -> String? {
        guard FileManager.default.isReadableFile(atPath: promptFilePath) else {
            return nil
        }
        guard let contents = try? String(contentsOfFile: promptFilePath, encoding: .utf8) else {
            return nil
        }
        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
        return trimmed.isEmpty ? nil : trimmed
    }
}

// Verify it instantiates
let s = SettingsTypeCheck(prefsInitialPrompt: "fallback")
print("Type check passed. initialPrompt = \(s.initialPrompt)")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `OpenSuperWhisper/Settings.swift:624` - promptFilePath is declared as `static let` initialized by a closure, so it is computed only once. This is fine because the home directory doesn&#39;t change during an app&#39;s lifetime, and the file *contents* are read freshly each time `fileBasedPrompt()` is called (which happens on every `Settings()` init). No issue here.
- ℹ️ `Readme.md:30` - README documents the feature under a new &#39;Configuration&#39; section as required by intent.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`swift test_file_based_prompt.swift` — 9 assertions covering: file absent → nil, file with content → trimmed, empty file → nil, whitespace-only → nil, re-read freshness across edits, multiline preservation, priority over Settings UI, fallback when absent</code>
- <code>`swift typecheck_settings_patch.swift` — validates the new code pattern compiles correctly with Foundation APIs</code>
- <code>`swift test_no_directory_autocreation.swift` — confirms no directory auto-creation when ~/.config/opensuperwhisper/ is absent</code>
- <code>`swift end_to_end_demo.swift` — full power-user workflow simulation matching README instructions</code>
- `Manual review of Readme.md Configuration section for accuracy against implementation`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `OpenSuperWhisper/Settings.swift` - Trailing whitespace on blank separator lines 628 and 659 (introduced by this change) was removed. The rest of the file has pre-existing trailing whitespace on many blank lines which is not in scope.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
