### PR TITLE
Add Ukrainian language support (Whisper engine)

### DIFF
--- a/OpenSuperWhisper/Utils/LanguageUtil.swift
+++ b/OpenSuperWhisper/Utils/LanguageUtil.swift
@@ -3,7 +3,7 @@ class LanguageUtil {
 
     static let availableLanguages = [
         "auto", "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
-        "he", "sv", "it", "id", "hi", "fi",
+        "he", "sv", "it", "id", "hi", "fi", "uk",
     ]
 
     static let parakeetV2Languages = ["en"]


### PR DESCRIPTION
Ukrainian (`uk`) was already supported for the Parakeet v3 engine and had a display name in `languageNames`, but was missing from `availableLanguages` - so it wasn't selectable on the default Whisper engine, even though Whisper transcribes Ukrainian natively.

This adds `uk` to `availableLanguages` so Ukrainian appears in the language picker for the Whisper engine.

No new display name needed (`"uk": "Ukrainian"` already exists), and the existing `LanguageSupportTests` continue to pass.