### PR TITLE
Add Vietnamese language option

### DIFF
--- a/OpenSuperWhisper/Utils/LanguageUtil.swift
+++ b/OpenSuperWhisper/Utils/LanguageUtil.swift
@@ -3,7 +3,7 @@ class LanguageUtil {
 
     static let availableLanguages = [
         "auto", "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
-        "he", "sv", "it", "id", "hi", "fi", "uk",
+        "he", "sv", "it", "id", "hi", "fi", "vi", "uk",
     ]
 
     static let parakeetV2Languages = ["en"]
@@ -35,6 +35,7 @@ class LanguageUtil {
         "id": "Indonesian",
         "hi": "Hindi",
         "fi": "Finnish",
+        "vi": "Vietnamese",
         "bg": "Bulgarian",
         "hr": "Croatian",
         "cs": "Czech",

--- a/OpenSuperWhisperTests/StorageAndLanguageSettingsTests.swift
+++ b/OpenSuperWhisperTests/StorageAndLanguageSettingsTests.swift
@@ -72,6 +72,8 @@ final class LanguageSupportTests: XCTestCase {
         XCTAssertEqual(languages, LanguageUtil.availableLanguages)
         XCTAssertTrue(languages.contains("auto"))
         XCTAssertTrue(languages.contains("zh"))
+        XCTAssertTrue(languages.contains("vi"))
+        XCTAssertEqual(LanguageUtil.languageNames["vi"], "Vietnamese")
     }
 
     func testSupportedLanguages_parakeetV2_isEnglishOnly() {


### PR DESCRIPTION
## Summary

- add Vietnamese (`vi`) to the Whisper language picker
- add the `Vietnamese` display name
- extend the existing language support regression test

## Why

Whisper supports Vietnamese, but `LanguageUtil.availableLanguages` currently omits the `vi` language code. As a result, users can only rely on automatic language detection and cannot explicitly select Vietnamese.

## Impact

Users can select Vietnamese when using the Whisper engine. Parakeet language support is unchanged because it uses its own language lists.

Because `getSystemLanguage()` filters through `availableLanguages`, Macs configured in Vietnamese can also resolve to `vi` instead of falling back to English.

## Validation

- `./run.sh build` — passed
- `LanguageSupportTests` — 5 passed
- Full `OpenSuperWhisperTests` suite was also run; four pre-existing environment-dependent integration tests failed (`ClipboardUtilPasteIntegrationTests` and Bluetooth device detection), while the language support tests passed.
