### PR TITLE
feat: add Enter-after-transcription setting

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -227,6 +227,15 @@ class IndicatorViewModel: ObservableObject {
                 // Paste but restore original clipboard (legacy behavior)
                 ClipboardUtil.insertText(finalText)
             }
+            if prefs.addEnterAfterTranscription {
+                // Some target apps process Cmd+V asynchronously, and the
+                // nonactivating indicator panel's hide spring is still settling
+                // here. Wait for both before sending Return so the foreground
+                // app, not the panel, receives it.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    ClipboardUtil.sendReturnKey()
+                }
+            }
         } else if prefs.autoCopyToClipboard {
             // Only copy to clipboard, don't paste
             ClipboardUtil.copyToClipboard(finalText)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -190,6 +190,12 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var addEnterAfterTranscription: Bool {
+        didSet {
+            AppPreferences.shared.addEnterAfterTranscription = addEnterAfterTranscription
+        }
+    }
+
     @Published var autoCopyToClipboard: Bool {
         didSet {
             AppPreferences.shared.autoCopyToClipboard = autoCopyToClipboard
@@ -224,6 +230,7 @@ class SettingsViewModel: ObservableObject {
         self.escCancelWithoutConfirmation = prefs.escCancelWithoutConfirmation
         self.startHiddenInMenuBar = prefs.startHiddenInMenuBar
         self.addSpaceAfterSentence = prefs.addSpaceAfterSentence
+        self.addEnterAfterTranscription = prefs.addEnterAfterTranscription
         self.autoCopyToClipboard = prefs.autoCopyToClipboard
         self.autoPasteTranscription = prefs.autoPasteTranscription
 
@@ -942,6 +949,20 @@ struct SettingsView: View {
                             }
                             Spacer()
                             Toggle("", isOn: $viewModel.addSpaceAfterSentence)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Add Enter After Transcription")
+                                    .font(.subheadline)
+                                Text("Presses Return after pasting, to submit the text")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $viewModel.addEnterAfterTranscription)
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
                                 .labelsHidden()
                         }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -123,6 +123,9 @@ final class AppPreferences {
     @UserDefault(key: "addSpaceAfterSentence", defaultValue: true)
     var addSpaceAfterSentence: Bool
 
+    @UserDefault(key: "addEnterAfterTranscription", defaultValue: false)
+    var addEnterAfterTranscription: Bool
+
     // Clipboard settings
     @UserDefault(key: "autoCopyToClipboard", defaultValue: false)
     var autoCopyToClipboard: Bool

--- a/OpenSuperWhisper/Utils/ClipboardUtil.swift
+++ b/OpenSuperWhisper/Utils/ClipboardUtil.swift
@@ -60,6 +60,20 @@ class ClipboardUtil {
         restorePasteboardContents(contents, to: pasteboard)
         return true
     }
+
+    /// Posts a Return key press. Sent as a real key event, not pasted text, so
+    /// the target app treats it as a submit rather than a newline character.
+    static func sendReturnKey() {
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false) else { return }
+        // Explicitly clear flags so Return stays Return even when the recording
+        // hotkey used a modifier key.
+        keyDown.flags = []
+        keyUp.flags = []
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
     
     private static func simulatePaste() {
         sendCmdV()


### PR DESCRIPTION
New "Add Enter After Transcription" toggle, off by default. When on, a Return key press is posted after the paste, so the target app submits the text instead of receiving a newline character.

Return is sent as a CGEvent with the flags explicitly cleared, otherwise a modifier still held from the recording hotkey corrupts it. The 0.5s delay covers target apps that process Cmd+V asynchronously and the indicator panel's hide spring, so the foreground app receives the key, not the panel.