### PR TITLE
Add Malayalam language support (Whisper engine)

### DIFF
--- a/OpenSuperWhisper/Utils/LanguageUtil.swift
+++ b/OpenSuperWhisper/Utils/LanguageUtil.swift
@@ -3,7 +3,7 @@ class LanguageUtil {
 
     static let availableLanguages = [
         "auto", "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
-        "he", "sv", "it", "id", "hi", "fi", "uk",
+        "he", "sv", "it", "id", "hi", "fi", "uk", "ml",
     ]
 
     static let parakeetV2Languages = ["en"]
@@ -49,6 +49,7 @@ class LanguageUtil {
         "sk": "Slovak",
         "sl": "Slovenian",
         "uk": "Ukrainian",
+        "ml": "Malayalam",
     ]
 
     static func supportedLanguages(engine: String, fluidAudioModelVersion: String) -> [String] {


### PR DESCRIPTION
Malayalam (`ml`) is natively supported by Whisper — it is in the multilingual tokenizer's `LANGUAGES` map (`"ml": "malayalam"`) — but it was missing from `LanguageUtil.availableLanguages`, so it never appeared in the language picker on the default Whisper engine.

Unlike Ukrainian (#196), `ml` also had no entry in `languageNames`, so this adds both:

- `ml` appended to `availableLanguages`
- `"ml": "Malayalam"` added to `languageNames` (without it the picker would render the raw code `ml`, since both call sites use `languageNames[code] ?? code`)

`parakeetV3Languages` is intentionally unchanged — Parakeet v3 is European-only, so Malayalam should not be offered for the FluidAudio engine. The existing `LanguageSupportTests` continue to pass: nothing asserts a fixed size or exact membership for `availableLanguages`, and `testAllParakeetV3LanguagesHaveDisplayNames` only iterates `parakeetV3Languages`.

Closes #200